### PR TITLE
%s filepath bug

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -121,6 +121,12 @@ func cliPrint(msg string, a ...interface{}) {
 	fmt.Fprintf(os.Stdout, msg, a...)
 }
 
+// cliPrintRaw is like cliPrint, but does no interpretation of placeholders in
+// msg.
+func cliPrintRaw(msg string) {
+	fmt.Fprint(os.Stdout, msg)
+}
+
 // info is a convenience to log a message at the Info level.
 func info(msg string, a ...interface{}) {
 	appLogger.Info(fmt.Sprintf(msg, a...))

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -313,8 +313,8 @@ func displayEntries(entries []*set.Entry) {
 			entry.LastError,
 		}
 
-		cliPrint(strings.Join(cols, "\t"))
-		cliPrint("\n")
+		cliPrintRaw(strings.Join(cols, "\t"))
+		cliPrintRaw("\n")
 	}
 }
 

--- a/put/baton.go
+++ b/put/baton.go
@@ -213,7 +213,7 @@ func (b *Baton) ensureCollection(clientIndex int, ri ex.RodsItem) error {
 		_, errl := b.collClients[clientIndex].ListItem(ex.Args{}, ri)
 
 		return errl
-	}, ri.IPath)
+	}, "collection failed: "+ri.IPath)
 	if err == nil {
 		return nil
 	}
@@ -369,7 +369,7 @@ func (b *Baton) closeConnections(clients []*ex.Client) {
 			client.StopIgnoreError()
 
 			return nil
-		}, "")
+		}, "close error")
 	}
 }
 
@@ -382,7 +382,7 @@ func (b *Baton) Stat(request *Request) (*ObjectInfo, error) {
 		it, errl = b.metaClient.ListItem(ex.Args{Timestamp: true, AVU: true}, *requestToRodsItem(request))
 
 		return errl
-	}, request.Remote)
+	}, "stat failed: "+request.Remote)
 
 	if err != nil {
 		if strings.Contains(err.Error(), extendoNotExist) {
@@ -460,7 +460,7 @@ func (b *Baton) RemoveMeta(path string, meta map[string]string) error {
 		_, errl := b.metaClient.MetaRem(ex.Args{}, *it)
 
 		return errl
-	}, path)
+	}, "remove meta error: "+path)
 
 	return err
 }
@@ -481,7 +481,7 @@ func (b *Baton) AddMeta(path string, meta map[string]string) error {
 		_, errl := b.metaClient.MetaAdd(ex.Args{}, *it)
 
 		return errl
-	}, path)
+	}, "add meta error: "+path)
 
 	return err
 }


### PR DESCRIPTION
Fix a status display bug for paths with %s in them.

Also adds a skipped test for baton not being able to cope with such paths. To be unskipped when bug fixed on their end.