### PR TITLE
CGO_ENABLED=0 server test fix

### DIFF
--- a/put/info.go
+++ b/put/info.go
@@ -104,9 +104,12 @@ func getUserAndGroupFromFileInfo(fi os.FileInfo, localPath string) (string, stri
 		return "", "", err
 	}
 
-	g, err := user.LookupGroupId(strconv.Itoa(int(stat.Gid)))
+	gid := strconv.Itoa(int(stat.Gid))
+	g, err := user.LookupGroupId(gid)
 	if err != nil {
-		return "", "", err
+		g = &user.Group{
+			Name: gid,
+		}
 	}
 
 	return u.Username, g.Name, nil


### PR DESCRIPTION
Return the group ID (as string) in place of group name if the group cannot be found; happens when CGO is disabled and using LDAP for users/groups.