### PR TITLE
Show walk errors in status

### DIFF
--- a/cmd/status.go
+++ b/cmd/status.go
@@ -255,9 +255,13 @@ func displaySet(s *set.Set) {
 
 	if s.Error != "" {
 		cliPrint("Status: unable to proceed\n")
-		cliPrint("Error: %s\n", strings.TrimSpace(s.Error))
+		cliPrint("Error: %s\n", s.Error)
 	} else {
 		cliPrint("Status: %s\n", s.Status)
+	}
+
+	if s.Warning != "" {
+		cliPrint("Warning: %s\n", s.Warning)
 	}
 
 	cliPrint("Discovery: %s\n", s.Discovered())

--- a/cmd/status.go
+++ b/cmd/status.go
@@ -255,7 +255,7 @@ func displaySet(s *set.Set) {
 
 	if s.Error != "" {
 		cliPrint("Status: unable to proceed\n")
-		cliPrint("Error: %s\n", s.Error)
+		cliPrint("Error: %s\n", strings.TrimSpace(s.Error))
 	} else {
 		cliPrint("Status: %s\n", s.Status)
 	}

--- a/main_test.go
+++ b/main_test.go
@@ -340,8 +340,8 @@ Global put client status (/10): 0 creating collections; 0 currently uploading
 Name: badPerms
 Transformer: `+transformer+`
 Monitored: false; Archive: false
-Status: unable to proceed
-Error: open `+badPermDir+`: permission denied
+Status: complete
+Warning: open `+badPermDir+`: permission denied
 Discovery:
 Num files: 0; Size files: 0 B
 Uploaded: 0; Failed: 0; Missing: 0
@@ -375,7 +375,6 @@ Num files: 1; Size files: 0 B (and counting)
 Uploaded: 0; Failed: 0; Missing: 0
 Example File: `+humgenFile+" => /humgen/teams/hgi/scratch125/mercury/ibackup/file_for_testsuite.do_not_delete")
 	})
-
 }
 
 // prepareSetWithEmptyDir creates a tempdir with a subdirectory inside it, and

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1598,7 +1598,7 @@ func TestServer(t *testing.T) { //nolint:cyclop
 					})
 
 					Convey("The system warns of possibly stuck uploads", func() {
-						handler.MakePutSlow(discovers[0], 600*time.Millisecond)
+						handler.MakePutSlow(discovers[0], 1200*time.Millisecond)
 
 						requests, errg := client.GetSomeUploadRequests()
 						So(errg, ShouldBeNil)
@@ -1616,7 +1616,7 @@ func TestServer(t *testing.T) { //nolint:cyclop
 								minMBperSecondUploadSpeed, 100*time.Millisecond, logger)
 						}()
 
-						<-time.After(300 * time.Millisecond)
+						<-time.After(600 * time.Millisecond)
 						gotSet, err = client.GetSetByID(exampleSet.Requester, exampleSet.ID())
 						So(err, ShouldBeNil)
 						So(gotSet.Status, ShouldEqual, set.Uploading)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1850,7 +1850,7 @@ func TestServer(t *testing.T) { //nolint:cyclop
 					So(remoteBackupExists, ShouldBeTrue)
 				})
 
-				Convey("and add a set containing directories that can't be accessed, which is shown as a set error", func() {
+				Convey("and add a set containing directories that can't be accessed, which is shown as a set warning", func() {
 					err = client.AddOrUpdateSet(exampleSet)
 					So(err, ShouldBeNil)
 
@@ -1892,9 +1892,9 @@ func TestServer(t *testing.T) { //nolint:cyclop
 					So(len(entries), ShouldEqual, 1)
 
 					So(gotSet.Warning, ShouldContainSubstring,
-						fmt.Sprintf("open %s: permission denied\n", filepath.Dir(pathExpected2)))
+						fmt.Sprintf("open %s: permission denied", filepath.Dir(pathExpected2)))
 					So(gotSet.Warning, ShouldContainSubstring,
-						fmt.Sprintf("open %s: permission denied\n", filepath.Dir(pathExpected3)))
+						fmt.Sprintf("open %s: permission denied", filepath.Dir(pathExpected3)))
 				})
 			})
 		})

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -1891,8 +1891,10 @@ func TestServer(t *testing.T) { //nolint:cyclop
 					So(err, ShouldBeNil)
 					So(len(entries), ShouldEqual, 1)
 
-					So(gotSet.Error, ShouldContainSubstring, fmt.Sprintf("open %s: permission denied\n", filepath.Dir(pathExpected2)))
-					So(gotSet.Error, ShouldContainSubstring, fmt.Sprintf("open %s: permission denied\n", filepath.Dir(pathExpected3)))
+					So(gotSet.Warning, ShouldContainSubstring,
+						fmt.Sprintf("open %s: permission denied\n", filepath.Dir(pathExpected2)))
+					So(gotSet.Warning, ShouldContainSubstring,
+						fmt.Sprintf("open %s: permission denied\n", filepath.Dir(pathExpected3)))
 				})
 			})
 		})

--- a/set/set.go
+++ b/set/set.go
@@ -163,6 +163,10 @@ type Set struct {
 	// Error holds any error that applies to the whole set, such as an issue
 	// with the Transformer. This is a read-only value.
 	Error string
+
+	// Warning contains errors that do not stop progression. This is a read-only
+	// value.
+	Warning string
 }
 
 // ID returns an ID for this set, generated deterministiclly from its Name and

--- a/set/set_test.go
+++ b/set/set_test.go
@@ -200,14 +200,19 @@ func TestSet(t *testing.T) {
 
 					So(db.GetByID("sdf"), ShouldBeNil)
 
-					Convey("And set an Error for it, which is cleared when we start discovery again", func() {
-						msg := "foo"
-						err = db.SetError(set.ID(), msg)
+					Convey("And set an Error and Warning for it, which are cleared when we start discovery again", func() {
+						errMsg := "fooErr"
+						err = db.SetError(set.ID(), errMsg)
+						So(err, ShouldBeNil)
+
+						warnMsg := "fooWarn"
+						err = db.SetWarning(set.ID(), warnMsg)
 						So(err, ShouldBeNil)
 
 						retrieved = db.GetByID(set.ID())
 						So(retrieved, ShouldNotBeNil)
-						So(retrieved.Error, ShouldEqual, msg)
+						So(retrieved.Error, ShouldEqual, errMsg)
+						So(retrieved.Warning, ShouldEqual, warnMsg)
 
 						err = db.SetDiscoveryStarted(set.ID())
 						So(err, ShouldBeNil)
@@ -215,6 +220,7 @@ func TestSet(t *testing.T) {
 						retrieved = db.GetByID(set.ID())
 						So(retrieved, ShouldNotBeNil)
 						So(retrieved.Error, ShouldBeBlank)
+						So(retrieved.Warning, ShouldBeBlank)
 					})
 
 					Convey("And set bool vals back to false on update", func() {


### PR DESCRIPTION
So users can see if subdirectories couldn't be accessed due to permissions issues, and were thus not backed up.