### PR TITLE
Fix zombie baton-do processes + Send all extendo logs to server log

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,12 +21,12 @@ install:
 
 test: export CGO_ENABLED = 1
 test:
-	@go test -tags netgo --count 1
+	@go test -tags netgo --count 1 .
 	@go test -tags netgo --count 1 $(shell go list ./... | tail -n+2)
 
 race: export CGO_ENABLED = 1
 race:
-	@go test -tags netgo -race --count 1
+	@go test -tags netgo -race --count 1 .
 	@go test -tags netgo -race --count 1 $(shell go list ./... | tail -n+2)
 
 bench: export CGO_ENABLED = 1

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -43,6 +43,8 @@ import (
 	gas "github.com/wtsi-hgi/go-authserver"
 	"github.com/wtsi-hgi/ibackup/put"
 	"github.com/wtsi-hgi/ibackup/server"
+	"github.com/wtsi-npg/logshim"
+	"github.com/wtsi-npg/logshim-zerolog/zlog"
 )
 
 const serverTokenBasename = ".ibackup.token"
@@ -242,7 +244,11 @@ func setServerLogger(path string) io.Writer {
 		logToFile(path)
 	}
 
-	return &log15Writer{logger: appLogger}
+	lw := &log15Writer{logger: appLogger}
+
+	logshim.InstallLogger(zlog.New(lw, logshim.ErrorLevel))
+
+	return lw
 }
 
 // logToSyslog sets our applogger to log to syslog, dies if it can't.

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/phayes/freeport v0.0.0-20220201140144-74d24b5ae9f5
 	github.com/rs/zerolog v1.29.1
 	github.com/sasha-s/go-deadlock v0.3.1
+	github.com/shirou/gopsutil v3.21.11+incompatible
 	github.com/smartystreets/goconvey v1.7.2
 	github.com/spf13/cobra v1.7.0
 	github.com/ugorji/go/codec v1.2.11
@@ -124,7 +125,6 @@ require (
 	github.com/rs/xid v1.5.0 // indirect
 	github.com/sb10/l15h v0.0.0-20170510122137-64c488bf8e22 // indirect
 	github.com/sb10/waitgroup v0.0.0-20200305124406-7ed665007efa // indirect
-	github.com/shirou/gopsutil v3.21.11+incompatible // indirect
 	github.com/sirupsen/logrus v1.9.0 // indirect
 	github.com/smartystreets/assertions v1.13.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/main_test.go
+++ b/main_test.go
@@ -37,6 +37,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"syscall"
 	"testing"
@@ -720,7 +721,6 @@ func TestHardlinks(t *testing.T) {
 		}
 
 		schedulerDeployment := os.Getenv("IBACKUP_TEST_SCHEDULER")
-
 		if schedulerDeployment == "" {
 			SkipConvey("skipping iRODS backup test since IBACKUP_TEST_SCHEDULER not set", func() {})
 
@@ -800,8 +800,8 @@ func TestManualMode(t *testing.T) {
 
 			return
 		}
-		tmpDir := t.TempDir()
 
+		tmpDir := t.TempDir()
 		file1 := filepath.Join(tmpDir, "file1")
 		file2 := filepath.Join(tmpDir, "file2")
 
@@ -836,6 +836,64 @@ func TestManualMode(t *testing.T) {
 		confirmFileContents(got1, fileContents1)
 		confirmFileContents(got2, fileContents2)
 	})
+}
+
+var ErrStringNotFound = errors.New("error not found in log")
+
+func TestExtendoLogging(t *testing.T) {
+	Convey("Error logging from extendo package should appear in server log", t, func() {
+		remotePath := remoteDBBackupPath()
+		if remotePath == "" {
+			SkipConvey("skipping iRODS backup test since IBACKUP_TEST_COLLECTION not set", func() {})
+
+			return
+		}
+
+		dir := t.TempDir()
+		s := new(TestServer)
+		s.prepareFilePaths(dir)
+		s.prepareConfig()
+
+		s.backupFile = filepath.Join(dir, "db.bak")
+		s.remoteDBFile = remotePath
+
+		s.startServer()
+
+		transformer, localDir, _ := prepareForSetWithEmptyDir(t)
+
+		toFind := "read error on stdout"
+
+		var run int64
+
+		internal.RetryUntilWorksCustom(t, func() error { //nolint:errcheck
+			s.addSetForTesting(t, "testForLogging"+strconv.FormatInt(run, 10), transformer, localDir)
+			run++
+
+			log := getLogString(s.logFile)
+
+			if strings.Contains(log, toFind) {
+				return nil
+			}
+
+			return ErrStringNotFound
+		}, 5*time.Second, 0)
+
+		log := getLogString(s.logFile)
+		So(log, ShouldContainSubstring, toFind)
+	})
+}
+
+func getLogString(file string) string {
+	logFile, err := os.Open(file)
+	So(err, ShouldBeNil)
+
+	logData, err := io.ReadAll(logFile)
+	So(err, ShouldBeNil)
+
+	err = logFile.Close()
+	So(err, ShouldBeNil)
+
+	return string(logData)
 }
 
 func getFileFromIRODS(remotePath, localPath string) {

--- a/set/db.go
+++ b/set/db.go
@@ -30,7 +30,6 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -1186,27 +1185,41 @@ func (d *DB) doBackup() error {
 	return d.doRemoteBackup()
 }
 
-func (d *DB) doRemoteBackup() error {
+func (d *DB) doRemoteBackup() (err error) {
 	if d.remoteBackupPath == "" {
 		return nil
 	}
 
-	dir := filepath.Dir(d.remoteBackupPath)
-
-	err := d.remoteBackupHandler.EnsureCollection(dir)
-	if err != nil {
-		return err
-	}
-
-	err = d.remoteBackupHandler.CollectionsDone()
-	if err != nil {
-		return err
-	}
-
-	return d.remoteBackupHandler.Put(&put.Request{
+	putter, err := put.New(d.remoteBackupHandler, []*put.Request{{
 		Local:  d.backupPath,
 		Remote: d.remoteBackupPath,
-	})
+	}})
+	if err != nil {
+		return err
+	}
+
+	defer func() {
+		if errc := putter.Cleanup(); err == nil {
+			err = errc
+		}
+	}()
+
+	if err = putter.CreateCollections(); err != nil {
+		return err
+	}
+
+	started, finished, skipped := putter.Put()
+
+	drainChannel(started)
+	drainChannel(finished)
+	drainChannel(skipped)
+
+	return err
+}
+
+func drainChannel(ch chan *put.Request) {
+	for range ch {
+	}
 }
 
 // SetMinimumTimeBetweenBackups sets the minimum time between successive

--- a/set/db.go
+++ b/set/db.go
@@ -1218,7 +1218,7 @@ func (d *DB) doRemoteBackup() (err error) {
 }
 
 func drainChannel(ch chan *put.Request) {
-	for range ch {
+	for range ch { //nolint:revive
 	}
 }
 


### PR DESCRIPTION
Also a minor change to Makefile to quiet the output of the main tests so that it matches the output style of the remaining tests.