### PR TITLE
Rename cmd getremote to list and add flags --local and --remote

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -87,11 +87,11 @@ func init() {
 	listCmd.Flags().StringVar(&lstUser, "user", currentUsername(),
 		"pretend to be this user (only works if you started the server)")
 	listCmd.Flags().StringVarP(&lstName, "name", "n", "",
-		"get local and remote paths for the set with this name")
+		"get local and remote paths for the --name'd set")
 	listCmd.Flags().BoolVarP(&lstLocal, "local", "l", false,
-		"get local paths only for the set with this name")
+		"only get local paths for the --name'd set")
 	listCmd.Flags().BoolVarP(&lstRemote, "remote", "r", false,
-		"get remote paths only for the set with this name")
+		"only get remote paths for the --name'd set")
 }
 
 // getRemote gets the set from the provided name and displays its remote paths.

--- a/main_test.go
+++ b/main_test.go
@@ -417,13 +417,18 @@ func TestNoServer(t *testing.T) {
 	})
 }
 
-func TestGetRemote(t *testing.T) {
+func TestList(t *testing.T) {
 	Convey("With a started server", t, func() {
 		s := NewTestServer(t)
 		So(s, ShouldNotBeNil)
 
-		Convey("With no --name given, getremote returns an error", func() {
-			s.confirmOutput(t, []string{"getremote"}, 1, "--name must be set")
+		Convey("With no --name given, list returns an error", func() {
+			s.confirmOutput(t, []string{"list"}, 1, "--name must be set")
+		})
+
+		Convey("With --local and --remote given, list returns an error", func() {
+			s.confirmOutput(t, []string{"list", "--name", "test", "--local", "--remote"},
+				1, "--local and --remote are mutually exclusive")
 		})
 
 		Convey("Given an added set defined with files", func() {
@@ -442,9 +447,22 @@ func TestGetRemote(t *testing.T) {
 
 				s.waitForStatus("testAddFiles", "Status: complete", 1*time.Second)
 
-				Convey("getremote tells the remote path for every file in the set", func() {
-					s.confirmOutput(t, []string{"getremote", "--name", "testAddFiles"}, 0,
-						"/remote/path/to/other/file\n/remote/path/to/some/file")
+				Convey("list tells the local path and remote path for every file in the set", func() {
+					s.confirmOutput(t, []string{"list", "--name", "testAddFiles"}, 0,
+						dir+"/path/to/other/file\t"+"/remote/path/to/other/file\n"+
+							dir+"/path/to/some/file\t"+"/remote/path/to/some/file")
+				})
+
+				Convey("list and --local tells the local path for every file in the set", func() {
+					s.confirmOutput(t, []string{"list", "--name", "testAddFiles", "--local"}, 0,
+						dir+"/path/to/other/file\n"+
+							dir+"/path/to/some/file")
+				})
+
+				Convey("list and --remote tells the remote path for every file in the set", func() {
+					s.confirmOutput(t, []string{"list", "--name", "testAddFiles", "--remote"}, 0,
+						"/remote/path/to/other/file\n"+
+							"/remote/path/to/some/file")
 				})
 			})
 
@@ -453,8 +471,8 @@ func TestGetRemote(t *testing.T) {
 					"--name", "testAddFiles", "--transformer", "humgen")
 				So(exitCode, ShouldEqual, 0)
 
-				Convey("getremote returns an error", func() {
-					s.confirmOutput(t, []string{"getremote", "--name", "testAddFiles"}, 1,
+				Convey("list returns an error", func() {
+					s.confirmOutput(t, []string{"list", "--name", "testAddFiles"}, 1,
 						"your transformer didn't work: not a valid humgen lustre path ["+
 							dir+"/path/to/other/file]")
 				})


### PR DESCRIPTION
Refactor list to output both local and remote paths if no flag is provided