### PR TITLE
Never skip empty files when getting

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -2199,6 +2199,7 @@ func TestManualMode(t *testing.T) {
 
 			internal.CreateTestFile(t, file1, "")
 			restoreFiles(t, file1+"\t"+remote1+"\n", "1 downloaded (1 replaced); 0 skipped; 0 failed; 0 missing\n")
+			confirmFileContents(t, file1, fileContents1)
 
 			So(exec.Command("imeta", "add", "-d", remote2, transfer.MetaKeySymlink, file1).Run(), ShouldBeNil)
 

--- a/main_test.go
+++ b/main_test.go
@@ -2097,7 +2097,7 @@ func TestManualMode(t *testing.T) {
 		remote1 := remotePath + "/" + "file1"
 		remote2 := remotePath + "/" + "file2"
 
-		fileContents1 := "abc"
+		fileContents1 := "123"
 		fileContents2 := "1234"
 
 		internal.CreateTestFile(t, file1, fileContents1)
@@ -2193,6 +2193,12 @@ func TestManualMode(t *testing.T) {
 			restoreFiles(t, file5+"\t"+remote1+"\n", "1 downloaded (0 replaced); 0 skipped; 0 failed; 0 missing\n", "-o")
 
 			confirmFileContents(t, file5, fileContents1)
+
+			err = os.Remove(file1)
+			So(err, ShouldBeNil)
+
+			internal.CreateTestFile(t, file1, "")
+			restoreFiles(t, file1+"\t"+remote1+"\n", "1 downloaded (1 replaced); 0 skipped; 0 failed; 0 missing\n")
 
 			So(exec.Command("imeta", "add", "-d", remote2, transfer.MetaKeySymlink, file1).Run(), ShouldBeNil)
 

--- a/transfer/put.go
+++ b/transfer/put.go
@@ -485,7 +485,7 @@ func (p *Putter) statPathsAndReturnOrPut(request *Request, putCh chan *Request, 
 
 func (p *Putter) getMetadataAndReturnOrPut(request *Request, putCh chan *Request, skipReturnCh chan *Request) {
 	lInfo, err := Stat(request.Local)
-	if err == nil && !p.overwrite {
+	if err == nil && lInfo.Size != 0 && !p.overwrite {
 		sendRequest(request, RequestStatusUnmodified, err, skipReturnCh)
 
 		return

--- a/transfer/put.go
+++ b/transfer/put.go
@@ -485,7 +485,7 @@ func (p *Putter) statPathsAndReturnOrPut(request *Request, putCh chan *Request, 
 
 func (p *Putter) getMetadataAndReturnOrPut(request *Request, putCh chan *Request, skipReturnCh chan *Request) {
 	lInfo, err := Stat(request.Local)
-	if err == nil && lInfo.Size != 0 && !p.overwrite {
+	if skipIfLocalFileIsNotEmptyAndNotOverwriting(lInfo, err, p.overwrite) {
 		sendRequest(request, RequestStatusUnmodified, err, skipReturnCh)
 
 		return
@@ -501,6 +501,10 @@ func (p *Putter) getMetadataAndReturnOrPut(request *Request, putCh chan *Request
 	request.Meta.LocalMeta = request.Meta.remoteMeta
 
 	sendGetRequest(request, lInfo, rInfo, putCh, skipReturnCh)
+}
+
+func skipIfLocalFileIsNotEmptyAndNotOverwriting(lInfo *ObjectInfo, err error, overwrite bool) bool {
+	return err == nil && lInfo.Size != 0 && !overwrite
 }
 
 func sendGetRequest(request *Request, lInfo, rInfo *ObjectInfo, putCh chan *Request, skipReturnCh chan *Request) {


### PR DESCRIPTION
Because failed gets can leave behind empty files, which are then treated as "success" skips on retry.