### PR TITLE
Do not recover readonly sets

### DIFF
--- a/server/setdb.go
+++ b/server/setdb.go
@@ -1336,6 +1336,10 @@ func (s *Server) recoverQueue() error {
 	}
 
 	for _, given := range sets {
+		if given.ReadOnly {
+			continue
+		}
+
 		err = s.recoverSet(given)
 		if err != nil {
 			given.RecoveryError(err)


### PR DESCRIPTION
Needed for server to start up when there are invalid readonly sets mid-discovery