### PR TITLE
HSI-162: Test removal of previously uploaded, now failing file

### DIFF
--- a/main_test.go
+++ b/main_test.go
@@ -3002,8 +3002,8 @@ func TestTrash(t *testing.T) {
 				err = os.Remove(file1)
 				So(err, ShouldBeNil)
 
-				err := syscall.Mkfifo(file1, userPerms)
-				So(err, ShouldBeNil)
+				e := syscall.Mkfifo(file1, userPerms)
+				So(e, ShouldBeNil)
 
 				exitCode, _ := s.runBinary(t, "retry", "--name", setName, "--all")
 				So(exitCode, ShouldEqual, 0)
@@ -3031,8 +3031,8 @@ func TestTrash(t *testing.T) {
 				setNameWithMissingFile := "setWithMissingFile"
 				s.addSetForTesting(t, setNameWithMissingFile, transformer, path)
 
-				err := os.Remove(file)
-				So(err, ShouldBeNil)
+				e := os.Remove(file)
+				So(e, ShouldBeNil)
 
 				s.waitForStatus(setNameWithMissingFile, "\nStatus: complete", 10*time.Second)
 				s.confirmOutputContains(t, []string{"status", "--name", setNameWithMissingFile, "-d"}, 0, file+"\tmissing")
@@ -3044,8 +3044,8 @@ func TestTrash(t *testing.T) {
 
 			Convey("Given a set with an abnormal file", func() {
 				file := filepath.Join(path, "abnormal-file")
-				err := syscall.Mkfifo(file, userPerms)
-				So(err, ShouldBeNil)
+				e := syscall.Mkfifo(file, userPerms)
+				So(e, ShouldBeNil)
 
 				setNameWithAbnormalFile := "setWithAbnormalFile"
 				s.addSetForTesting(t, setNameWithAbnormalFile, transformer, file)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -4009,7 +4009,6 @@ func TestDiscoveryCoordinator(t *testing.T) {
 
 			So(callbackCalled.Load(), ShouldBeTrue)
 		})
-
 	})
 }
 


### PR DESCRIPTION
https://jira.sanger.ac.uk/browse/HSI-162

I couldn't implement the failure so instead I did a test with abnormal file - technically it is the same situation (abnormal files are not uploaded to remote)