### PR TITLE
HSI 166

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -159,7 +159,7 @@ func init() {
 	}
 }
 
-func getAllSetsFromDBAndDisplayPaths(dbPath string, local, remote, uploaded, //nolint:funlen
+func getAllSetsFromDBAndDisplayPaths(dbPath string, local, remote, uploaded, //nolint:funlen,gocyclo
 	deleted, size, encode bool,
 ) {
 	db, err := set.NewRO(dbPath)
@@ -180,12 +180,13 @@ func getAllSetsFromDBAndDisplayPaths(dbPath string, local, remote, uploaded, //n
 
 	var filter set.FileEntryFilter
 
-	if uploaded && deleted {
+	switch {
+	case uploaded && deleted:
 		filter = set.FileEntryFilterOrphaned
-	} else if deleted {
-		filter = set.FileEntryFilterMissing
-	} else if uploaded {
+	case uploaded:
 		filter = set.FileEntryFilterUploaded
+	case deleted:
+		filter = set.FileEntryFilterMissing
 	}
 
 	for _, s := range sets {
@@ -248,11 +249,12 @@ func getSetFromServerAndDisplayPaths(client *server.Client,
 
 	getFiles := client.GetFiles
 
-	if uploaded && deleted {
+	switch {
+	case uploaded && deleted:
 		getFiles = client.GetOrphanedFiles
-	} else if deleted {
+	case deleted:
 		getFiles = client.GetMissingFiles
-	} else if uploaded {
+	case uploaded:
 		getFiles = client.GetUploadedFiles
 	}
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -150,7 +150,7 @@ func init() {
 	listCmd.Flags().BoolVarP(&lstBase64, "base64", "b", false,
 		"output paths base64 encoded")
 	listCmd.Flags().BoolVar(&lstLastState, "last-state", false,
-		"show files that were uploaded and still existed locally during the last discovery scan (excludes orphaned files)")
+		"show uploaded files excluding orphaned ones")
 
 	if isAdmin() {
 		listCmd.Flags().BoolVar(&lstTrash, "trash", false,

--- a/main_test.go
+++ b/main_test.go
@@ -269,6 +269,8 @@ func (s *TestServer) waitForServer() {
 
 	status := retry.Do(ctx, func() error {
 		clientCmd := exec.Command("./"+app, cmd...)
+		clientCmd.Stdout = os.Stdout
+		clientCmd.Stderr = os.Stderr
 		clientCmd.Env = []string{"XDG_STATE_HOME=" + s.dir}
 
 		return clientCmd.Run()

--- a/main_test.go
+++ b/main_test.go
@@ -728,14 +728,14 @@ func TestList(t *testing.T) {
 	Convey("Given a server configured with a upload location and scheduler", t, func() {
 		remotePath := os.Getenv("IBACKUP_TEST_COLLECTION")
 		if remotePath == "" {
-			Convey("skipping iRODS backup test since IBACKUP_TEST_COLLECTION not set", func() {})
+			SkipConvey("skipping iRODS backup test since IBACKUP_TEST_COLLECTION not set", func() {})
 
 			return
 		}
 
 		schedulerDeployment := os.Getenv("IBACKUP_TEST_SCHEDULER")
 		if schedulerDeployment == "" {
-			Convey("skipping iRODS backup test since IBACKUP_TEST_SCHEDULER not set", func() {})
+			SkipConvey("skipping iRODS backup test since IBACKUP_TEST_SCHEDULER not set", func() {})
 
 			return
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -683,8 +683,8 @@ func TestList(t *testing.T) {
 			So(err, ShouldBeNil)
 
 			So(os.MkdirAll(dir+"/path/to/other/", 0700), ShouldBeNil)
-			So(os.WriteFile(dir+"/path/to/other/file", []byte("data"), 0600), ShouldBeNil)
-			So(os.WriteFile(dir+"/path/to/other/file2", []byte("data"), 0600), ShouldBeNil)
+			internal.CreateTestFile(t, filepath.Join(dir, "/path/to/other/file"), "data")
+			internal.CreateTestFile(t, filepath.Join(dir, "/path/to/other/file2"), "data")
 
 			setName := "testAddFiles_" + time.Now().Format("20060102150405")
 

--- a/main_test.go
+++ b/main_test.go
@@ -702,22 +702,19 @@ func TestList(t *testing.T) {
 				s.confirmOutput(t, []string{"list", "--name", setName, "--local", "--last-state"}, 0,
 					uploadFile1Path+"\n"+uploadFile2Path)
 
-				uploadFile3Path := filepath.Join(dir, "file3")
-				internal.CreateTestFile(t, uploadFile3Path, "new data")
-
-				exitCode, _ := s.runBinary(t, "edit", "--name", setName, "--add", uploadFile3Path)
+				exitCode, _ := s.runBinary(t, "retry", "--all", "--name", setName)
 				So(exitCode, ShouldEqual, 0)
 				s.waitForStatus(setName, "Status: complete", 20*time.Second)
 
 				Convey("Then list --uploaded shows all uploaded files, including orphans", func() {
 					s.confirmOutput(t, []string{"list", "--name", setName, "--local", "--uploaded"}, 0,
-						uploadFile1Path+"\n"+uploadFile2Path+"\n"+uploadFile3Path)
+						uploadFile1Path+"\n"+uploadFile2Path)
 				})
 
 				Convey("Then list --last-state shows only uploaded files that still existed locally at last discovery",
 					func() {
 						s.confirmOutput(t, []string{"list", "--name", setName, "--local", "--last-state"}, 0,
-							uploadFile1Path+"\n"+uploadFile3Path)
+							uploadFile1Path)
 						s.confirmOutputDoesNotContain(t, []string{"list", "--name", setName, "--local", "--last-state"}, 0,
 							uploadFile2Path)
 					})

--- a/server/client.go
+++ b/server/client.go
@@ -248,23 +248,31 @@ func (c *Client) TriggerDiscovery(setID string) error {
 // GetFiles gets the defined and discovered file paths and their backup status
 // for the given set.
 func (c *Client) GetFiles(setID string) ([]*set.Entry, error) {
-	var entries []*set.Entry
-
-	err := c.getThing(EndPointAuthEntries+"/"+setID, &entries)
-
-	for _, entry := range entries {
-		entry.CorrectFromJSON()
-	}
-
-	return entries, err
+	return c.getEntries(setID, EndPointAuthEntries)
 }
 
 // GetUploadedFiles gets the uploaded file paths and their backup status for the
 // given set.
 func (c *Client) GetUploadedFiles(setID string) ([]*set.Entry, error) {
+	return c.getEntries(setID, EndPointAuthUploadedEntries)
+}
+
+// GetOrphanedFiles gets the orphaned file paths and their backup status for the
+// given set.
+func (c *Client) GetOrphanedFiles(setID string) ([]*set.Entry, error) {
+	return c.getEntries(setID, EndPointAuthOrphanedEntries)
+}
+
+// GetMissingFiles gets the missing file paths and their backup status for the
+// given set.
+func (c *Client) GetMissingFiles(setID string) ([]*set.Entry, error) {
+	return c.getEntries(setID, EndPointAuthMissingEntries)
+}
+
+func (c *Client) getEntries(setID string, endPoint string) ([]*set.Entry, error) {
 	var entries []*set.Entry
 
-	err := c.getThing(EndPointAuthUploadedEntries+"/"+setID, &entries)
+	err := c.getThing(endPoint+"/"+setID, &entries)
 
 	for _, entry := range entries {
 		entry.CorrectFromJSON()
@@ -291,15 +299,7 @@ func (c *Client) GetExampleFile(setID string) (*set.Entry, error) {
 // GetDirs gets the directories for the given set that were supplied to
 // SetDirs().
 func (c *Client) GetDirs(setID string) ([]*set.Entry, error) {
-	var entries []*set.Entry
-
-	err := c.getThing(EndPointAuthDirs+"/"+setID, &entries)
-
-	for _, entry := range entries {
-		entry.CorrectFromJSON()
-	}
-
-	return entries, err
+	return c.getEntries(setID, EndPointAuthDirs)
 }
 
 // FailedEntries holds failed Entries and the number of failed ones that were

--- a/server/client.go
+++ b/server/client.go
@@ -257,16 +257,10 @@ func (c *Client) GetUploadedFiles(setID string) ([]*set.Entry, error) {
 	return c.getEntries(setID, EndPointAuthUploadedEntries)
 }
 
-// GetOrphanedFiles gets the orphaned file paths and their backup status for the
-// given set.
-func (c *Client) GetOrphanedFiles(setID string) ([]*set.Entry, error) {
-	return c.getEntries(setID, EndPointAuthOrphanedEntries)
-}
-
-// GetMissingFiles gets the missing file paths and their backup status for the
-// given set.
-func (c *Client) GetMissingFiles(setID string) ([]*set.Entry, error) {
-	return c.getEntries(setID, EndPointAuthMissingEntries)
+// GetLastStateFiles gets the uploaded file paths (excluding orphaned) and their
+// backup status for the given set.
+func (c *Client) GetLastStateFiles(setID string) ([]*set.Entry, error) {
+	return c.getEntries(setID, EndPointAuthLastStateEntries)
 }
 
 func (c *Client) getEntries(setID string, endPoint string) ([]*set.Entry, error) {

--- a/server/setdb.go
+++ b/server/setdb.go
@@ -50,21 +50,22 @@ import (
 )
 
 const (
-	setPath           = "/set"
-	filePath          = "/files"
-	dirPath           = "/dirs"
-	entryPath         = "/entries"
-	uploadedEntryPath = "/uploaded_entries"
-	orphanedEntryPath = "/orphaned_entries"
-	missingEntryPath  = "/missing_entries"
-	exampleEntryPath  = "/example_entries"
-	failedEntryPath   = "/failed_entries"
-	discoveryPath     = "/discover"
-	requestsPath      = "/requests"
-	workingPath       = "/working"
-	fileStatusPath    = "/file_status"
-	fileRetryPath     = "/retry"
-	removePathsPath   = "/remove_paths"
+	setPath            = "/set"
+	filePath           = "/files"
+	dirPath            = "/dirs"
+	entryPath          = "/entries"
+	uploadedEntryPath  = "/uploaded_entries"
+	orphanedEntryPath  = "/orphaned_entries"
+	missingEntryPath   = "/missing_entries"
+	lastStateEntryPath = "/laststate_entries"
+	exampleEntryPath   = "/example_entries"
+	failedEntryPath    = "/failed_entries"
+	discoveryPath      = "/discover"
+	requestsPath       = "/requests"
+	workingPath        = "/working"
+	fileStatusPath     = "/file_status"
+	fileRetryPath      = "/retry"
+	removePathsPath    = "/remove_paths"
 
 	// EndPointAuthSet is the endpoint for getting and setting sets.
 	EndPointAuthSet = gas.EndPointAuth + setPath
@@ -82,13 +83,9 @@ const (
 	// entries.
 	EndPointAuthUploadedEntries = gas.EndPointAuth + uploadedEntryPath
 
-	// EndPointAuthOrphanedEntries is the endpoint for getting set orphaned
-	// entries.
-	EndPointAuthOrphanedEntries = gas.EndPointAuth + orphanedEntryPath
-
-	// EndPointAuthMissingEntries is the endpoint for getting set missing
-	// entries.
-	EndPointAuthMissingEntries = gas.EndPointAuth + missingEntryPath
+	// EndPointAuthLastStateEntries is the endpoint for getting uploaded entries
+	// excluding orphaned entries.
+	EndPointAuthLastStateEntries = gas.EndPointAuth + lastStateEntryPath
 
 	// EndPointAuthExampleEntry is the endpoint for getting set entries.
 	EndPointAuthExampleEntry = gas.EndPointAuth + exampleEntryPath
@@ -288,8 +285,7 @@ func (s *Server) addDBEndpoints(authGroup *gin.RouterGroup) {
 
 	authGroup.GET(entryPath+idParam, s.getEntries)
 	authGroup.GET(uploadedEntryPath+idParam, s.getUploadedEntries)
-	authGroup.GET(orphanedEntryPath+idParam, s.getOrphanedEntries)
-	authGroup.GET(missingEntryPath+idParam, s.getMissingEntries)
+	authGroup.GET(lastStateEntryPath+idParam, s.getLastStateEntries)
 
 	authGroup.GET(exampleEntryPath+idParam, s.getExampleEntry)
 
@@ -1308,12 +1304,8 @@ func (s *Server) getUploadedEntries(c *gin.Context) {
 	s.getFileEntries(c, set.FileEntryFilterUploaded)
 }
 
-func (s *Server) getOrphanedEntries(c *gin.Context) {
-	s.getFileEntries(c, set.FileEntryFilterOrphaned)
-}
-
-func (s *Server) getMissingEntries(c *gin.Context) {
-	s.getFileEntries(c, set.FileEntryFilterMissing)
+func (s *Server) getLastStateEntries(c *gin.Context) {
+	s.getFileEntries(c, set.FileEntryFilterLastState)
 }
 
 // getExampleEntry gets the first defined file entry for the set with the

--- a/server/setdb.go
+++ b/server/setdb.go
@@ -55,8 +55,6 @@ const (
 	dirPath            = "/dirs"
 	entryPath          = "/entries"
 	uploadedEntryPath  = "/uploaded_entries"
-	orphanedEntryPath  = "/orphaned_entries"
-	missingEntryPath   = "/missing_entries"
 	lastStateEntryPath = "/laststate_entries"
 	exampleEntryPath   = "/example_entries"
 	failedEntryPath    = "/failed_entries"

--- a/server/setdb.go
+++ b/server/setdb.go
@@ -54,7 +54,9 @@ const (
 	filePath          = "/files"
 	dirPath           = "/dirs"
 	entryPath         = "/entries"
-	uploadedEntryPath = "/orphaned_entries"
+	uploadedEntryPath = "/uploaded_entries"
+	orphanedEntryPath = "/orphaned_entries"
+	missingEntryPath  = "/missing_entries"
 	exampleEntryPath  = "/example_entries"
 	failedEntryPath   = "/failed_entries"
 	discoveryPath     = "/discover"
@@ -79,6 +81,14 @@ const (
 	// EndPointAuthUploadedEntries is the endpoint for getting set uploaded
 	// entries.
 	EndPointAuthUploadedEntries = gas.EndPointAuth + uploadedEntryPath
+
+	// EndPointAuthOrphanedEntries is the endpoint for getting set orphaned
+	// entries.
+	EndPointAuthOrphanedEntries = gas.EndPointAuth + orphanedEntryPath
+
+	// EndPointAuthMissingEntries is the endpoint for getting set missing
+	// entries.
+	EndPointAuthMissingEntries = gas.EndPointAuth + missingEntryPath
 
 	// EndPointAuthExampleEntry is the endpoint for getting set entries.
 	EndPointAuthExampleEntry = gas.EndPointAuth + exampleEntryPath
@@ -278,6 +288,9 @@ func (s *Server) addDBEndpoints(authGroup *gin.RouterGroup) {
 
 	authGroup.GET(entryPath+idParam, s.getEntries)
 	authGroup.GET(uploadedEntryPath+idParam, s.getUploadedEntries)
+	authGroup.GET(orphanedEntryPath+idParam, s.getOrphanedEntries)
+	authGroup.GET(missingEntryPath+idParam, s.getMissingEntries)
+
 	authGroup.GET(exampleEntryPath+idParam, s.getExampleEntry)
 
 	authGroup.GET(dirPath+idParam, s.getDirs)
@@ -1293,6 +1306,14 @@ func (s *Server) getFileEntries(c *gin.Context, filter func(*set.Entry) bool) {
 
 func (s *Server) getUploadedEntries(c *gin.Context) {
 	s.getFileEntries(c, set.FileEntryFilterUploaded)
+}
+
+func (s *Server) getOrphanedEntries(c *gin.Context) {
+	s.getFileEntries(c, set.FileEntryFilterOrphaned)
+}
+
+func (s *Server) getMissingEntries(c *gin.Context) {
+	s.getFileEntries(c, set.FileEntryFilterMissing)
 }
 
 // getExampleEntry gets the first defined file entry for the set with the

--- a/set/db.go
+++ b/set/db.go
@@ -1596,6 +1596,16 @@ func FileEntryFilterUploaded(e *Entry) bool {
 		e.Status == Orphaned || e.Status == Skipped
 }
 
+// FileEntryFilterOrphaned is a FileEntryFilter that filters on orphaned files.
+func FileEntryFilterOrphaned(e *Entry) bool {
+	return e.Status == Orphaned
+}
+
+// FileEntryFilterMissing is a FileEntryFilter that filters on missing files.
+func FileEntryFilterMissing(e *Entry) bool {
+	return e.Status == Missing
+}
+
 // GetFileEntries returns all the file entries for the given set (both
 // SetFileEntries and SetDiscoveredEntries).
 func (d *DBRO) GetFileEntries(setID string, filter FileEntryFilter) ([]*Entry, error) {

--- a/set/db.go
+++ b/set/db.go
@@ -1597,7 +1597,7 @@ func FileEntryFilterUploaded(e *Entry) bool {
 }
 
 // FileEntryFilterLastState is a FileEntryFilter that filters on uploaded
-// files(excluding orphaned files).
+// files (excluding orphaned files).
 func FileEntryFilterLastState(e *Entry) bool {
 	return e.Status == Uploaded || e.Status == Replaced || e.Status == Skipped
 }

--- a/set/db.go
+++ b/set/db.go
@@ -1596,14 +1596,10 @@ func FileEntryFilterUploaded(e *Entry) bool {
 		e.Status == Orphaned || e.Status == Skipped
 }
 
-// FileEntryFilterOrphaned is a FileEntryFilter that filters on orphaned files.
-func FileEntryFilterOrphaned(e *Entry) bool {
-	return e.Status == Orphaned
-}
-
-// FileEntryFilterMissing is a FileEntryFilter that filters on missing files.
-func FileEntryFilterMissing(e *Entry) bool {
-	return e.Status == Missing
+// FileEntryFilterLastState is a FileEntryFilter that filters on uploaded
+// files(excluding orphaned files).
+func FileEntryFilterLastState(e *Entry) bool {
+	return e.Status == Uploaded || e.Status == Replaced || e.Status == Skipped
 }
 
 // GetFileEntries returns all the file entries for the given set (both


### PR DESCRIPTION
Currently it works by checking the existence of local files.

Instead, it needs to work without checking local existence, but by quering orphaned files in the database.

This is so that it will work in a disaster recovery situation, when no files exist locally, but you want to restore to the state of the last monitor.

https://jira.sanger.ac.uk/browse/HSI-166