### PR TITLE
HSI-159 As a user I'd like to do a one-time sync to delete stale files from iRODS, so I don't waste space in iRODS

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -404,7 +404,7 @@ func add(client *server.Client, name, requester, transformer, description string
 		return err
 	}
 
-	return client.TriggerDiscovery(set.ID())
+	return client.TriggerDiscovery(set.ID(), false)
 }
 
 func checkExistingSet(client *server.Client, name, requester string) (*set.Set, error) {

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -120,6 +120,10 @@ preexisting backup set.`,
 			return err
 		}
 
+		if editSyncWithDeletion {
+			return syncWithDeletion(client, userSet)
+		}
+
 		err = editSetMetaData(userSet, editMetaData, editReason, editReview, editRemovalDate)
 		if err != nil {
 			return err
@@ -366,4 +370,8 @@ func isParentDirInSet(sid, path string, client *server.Client) (bool, error) {
 	}
 
 	return false, nil
+}
+
+func syncWithDeletion(client *server.Client, set *set.Set) error {
+	return client.SyncWithDeletion(set.ID())
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -59,6 +59,7 @@ var (
 	editMakeWritable        bool
 	editHide                bool
 	editUnHide              bool
+	editSyncWithDeletion    bool
 )
 
 var (
@@ -212,6 +213,9 @@ func init() { //nolint:funlen
 		"hide set when viewing status")
 	editCmd.Flags().BoolVar(&editUnHide, "unhide", false,
 		"unhide set when viewing status")
+	editCmd.Flags().BoolVar(&editSyncWithDeletion, "sync-with-deletion", false,
+		"one-time upload of files missing remotely or changed locally and delete "+
+			"remote files missing locally")
 
 	if err := editCmd.MarkFlagRequired("name"); err != nil {
 		die(err)

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -59,7 +59,6 @@ var (
 	editMakeWritable        bool
 	editHide                bool
 	editUnHide              bool
-	editSyncWithDeletion    bool
 )
 
 var (
@@ -118,10 +117,6 @@ preexisting backup set.`,
 		userSet, err := client.GetSetByName(editUser, editSetName)
 		if err != nil {
 			return err
-		}
-
-		if editSyncWithDeletion {
-			return syncWithDeletion(client, userSet)
 		}
 
 		err = editSetMetaData(userSet, editMetaData, editReason, editReview, editRemovalDate)
@@ -217,9 +212,6 @@ func init() { //nolint:funlen
 		"hide set when viewing status")
 	editCmd.Flags().BoolVar(&editUnHide, "unhide", false,
 		"unhide set when viewing status")
-	editCmd.Flags().BoolVar(&editSyncWithDeletion, "sync-with-deletion", false,
-		"one-time upload of files missing remotely or changed locally and delete "+
-			"remote files missing locally")
 
 	if err := editCmd.MarkFlagRequired("name"); err != nil {
 		die(err)
@@ -370,8 +362,4 @@ func isParentDirInSet(sid, path string, client *server.Client) (bool, error) {
 	}
 
 	return false, nil
-}
-
-func syncWithDeletion(client *server.Client, set *set.Set) error {
-	return client.SyncWithDeletion(set.ID())
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -322,7 +322,7 @@ func updateSet(client *server.Client, sid, path string) error {
 		return err
 	}
 
-	return client.TriggerDiscovery(sid)
+	return client.TriggerDiscovery(sid, false)
 }
 
 // addFileToSet will add the given path to the set if its parent dir is not in

--- a/cmd/retry.go
+++ b/cmd/retry.go
@@ -27,15 +27,9 @@
 package cmd
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 	"github.com/wtsi-hgi/ibackup/server"
 	"github.com/wtsi-hgi/ibackup/set"
-)
-
-var (
-	ErrSetNoName = errors.New("you must specify --name")
 )
 
 // options for this cmd.
@@ -60,13 +54,6 @@ environment variable, or overriding that with the --cert argument).
 If you are the user who started the ibackup server, you can use the --user
 option to retry the given requestor's backup sets, instead of your own.
 `,
-	PreRunE: func(_ *cobra.Command, _ []string) error {
-		if retrySet == "" {
-			return ErrSetNoName
-		}
-
-		return nil
-	},
 	RunE: func(_ *cobra.Command, _ []string) error {
 		ensureURLandCert()
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -61,13 +61,6 @@ environment variable, or overriding that with the --cert argument).
 If you are the user who started the ibackup server, you can use the --user
 option to retry the given requestor's backup sets, instead of your own.	
 `,
-	PreRunE: func(_ *cobra.Command, _ []string) error {
-		if syncSetName == "" {
-			return ErrSetNoName
-		}
-
-		return nil
-	},
 	RunE: func(_ *cobra.Command, _ []string) error {
 		ensureURLandCert()
 

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2025 Genome Research Ltd.
+ *
+ * Author: Sendu Bala <sb10@sanger.ac.uk>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining
+ * a copy of this software and associated documentation files (the
+ * "Software"), to deal in the Software without restriction, including
+ * without limitation the rights to use, copy, modify, merge, publish,
+ * distribute, sublicense, and/or sell copies of the Software, and to
+ * permit persons to whom the Software is furnished to do so, subject to
+ * the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included
+ * in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+ * MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+ * IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+ * CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+ * TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+ * SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ ******************************************************************************/
+
+package cmd
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+	"github.com/wtsi-hgi/ibackup/server"
+	"github.com/wtsi-hgi/ibackup/set"
+)
+
+var syncUser string
+var syncSetName string
+var syncDelete bool
+
+var (
+	ErrSyncNoName = errors.New("you must specify --name")
+)
+
+// syncCmd represents the sync command.
+var syncCmd = &cobra.Command{
+	Use:   "sync",
+	Short: "Perform one-time sync operations on a set",
+	Long:  `Perform one-time sync operations on a set.`,
+	PreRunE: func(_ *cobra.Command, _ []string) error {
+		if syncSetName == "" {
+			return ErrSyncNoName
+		}
+
+		return nil
+	},
+	RunE: func(_ *cobra.Command, _ []string) error {
+		ensureURLandCert()
+
+		client, err := newServerClient(serverURL, serverCert)
+		if err != nil {
+			return err
+		}
+
+		userSet, err := client.GetSetByName(syncUser, syncSetName)
+		if err != nil {
+			return err
+		}
+
+		if syncDelete {
+			return syncWithDeletion(client, userSet)
+		}
+
+		return nil
+	},
+}
+
+func init() { //nolint:funlen
+	RootCmd.AddCommand(syncCmd)
+
+	syncCmd.Flags().StringVar(&syncUser, "user", currentUsername(), helpTextuser)
+	syncCmd.Flags().StringVarP(&syncSetName, "name", "n", "", helpTextName)
+	syncCmd.Flags().BoolVar(&syncDelete, "delete", false,
+		"delete extraneous files from iRODS")
+
+	if err := syncCmd.MarkFlagRequired("name"); err != nil {
+		die(err)
+	}
+}
+
+func syncWithDeletion(client *server.Client, set *set.Set) error {
+	return client.SyncWithDeletion(set.ID())
+}

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -45,10 +45,13 @@ required --name to choose the set.
 
 This re-triggers discovery of files in any directories specified as part of your
 set. It's like starting over from the beginning, though any files already
-uploaded to iRODS and unchanged locally will not be uploaded again.
+uploaded to iRODS and unchanged locally will not be uploaded again. This is also
+the same as what happens if you had set the --monitor option and the time period
+had elapsed.
 
 If the --delete option is given, then any files that are no longer present
-locally will be deleted from iRODS.
+locally will be deleted from iRODS. This is the same as what happens if you had
+set the --monitor option along with --monitor-removals.
 
 You need to supply the ibackup server's URL in the form domain:port (using the
 IBACKUP_SERVER_URL environment variable, or overriding that with the --url

--- a/cmd/sync.go
+++ b/cmd/sync.go
@@ -29,8 +29,6 @@ import (
 	"errors"
 
 	"github.com/spf13/cobra"
-	"github.com/wtsi-hgi/ibackup/server"
-	"github.com/wtsi-hgi/ibackup/set"
 )
 
 var syncUser string
@@ -66,11 +64,7 @@ var syncCmd = &cobra.Command{
 			return err
 		}
 
-		if syncDelete {
-			return syncWithDeletion(client, userSet)
-		}
-
-		return nil
+		return client.TriggerDiscovery(userSet.ID(), syncDelete)
 	},
 }
 
@@ -85,8 +79,4 @@ func init() { //nolint:funlen
 	if err := syncCmd.MarkFlagRequired("name"); err != nil {
 		die(err)
 	}
-}
-
-func syncWithDeletion(client *server.Client, set *set.Set) error {
-	return client.SyncWithDeletion(set.ID())
 }

--- a/main_test.go
+++ b/main_test.go
@@ -4356,7 +4356,7 @@ func TestSync(t *testing.T) {
 
 		Convey("sync requires --name", func() {
 			s.confirmOutputContains(t, []string{"sync"}, 1,
-				cmd.ErrSetNoName.Error())
+				"Error: required flag(s) \"name\" not set")
 		})
 
 		Convey("And a set with some uploaded files, one of which is then deleted locally and "+
@@ -4448,7 +4448,7 @@ func TestRetry(t *testing.T) {
 
 		Convey("retry requires --name", func() {
 			s.confirmOutputContains(t, []string{"retry"}, 1,
-				cmd.ErrSetNoName.Error())
+				"Error: required flag(s) \"name\" not set")
 		})
 
 		Convey("And a set with a file that fails to upload", func() {

--- a/main_test.go
+++ b/main_test.go
@@ -4385,26 +4385,27 @@ func TestSync(t *testing.T) {
 			setFile2 := filepath.Join(setDir, "file2")
 			internal.CreateTestFileOfLength(t, setFile2, 1)
 
-			// Convey("sync requires --name", func() {
-			// 	exitCode, _ = s.runBinary(t, "sync")
-			// 	So(exitCode, ShouldEqual, 1)
-			// })
+			Convey("sync requires --name", func() {
+				s.confirmOutputContains(t, []string{"sync"}, 1,
+					cmd.ErrSyncNoName.Error())
+			})
 
-			// Convey("sync without --delete uploads new files without deleting locally deleted ones", func() {
-			// 	exitCode, _ = s.runBinary(t, "sync", "--name", setName)
-			// 	So(exitCode, ShouldEqual, 0)
+			Convey("sync without --delete uploads new files without deleting locally deleted ones", func() {
+				exitCode, _ = s.runBinary(t, "sync", "--name", setName)
+				So(exitCode, ShouldEqual, 0)
 
-			// 	s.waitForStatus(setName, "Status: complete", timeout)
+				s.waitForStatus(setName, "Status: complete", timeout)
 
-			// 	exitCode, output = s.runBinaryWithNoLogging(t, "status", "--name", setName, "-d")
-			// 	So(exitCode, ShouldEqual, 0)
+				exitCode, output = s.runBinaryWithNoLogging(t, "status", "--name", setName, "-d")
+				So(exitCode, ShouldEqual, 0)
 
-			// 	So(output, ShouldContainSubstring, "Num files: 3")
-			// 	So(output, ShouldContainSubstring, "Uploaded: 2;")
-			// 	So(output, ShouldContainSubstring, "Orphaned: 1;")
-			// 	So(output, ShouldContainSubstring, "Size (total/recently uploaded/recently removed): 3 B / 1 B / 0 B")
-			// 	So(output, ShouldContainSubstring, setFileToBeDeleted)
-			// })
+				So(output, ShouldContainSubstring, "Num files: 3")
+				So(output, ShouldContainSubstring, "Uploaded: 1;")
+				So(output, ShouldContainSubstring, "Skipped: 1;")
+				So(output, ShouldContainSubstring, "Orphaned: 1;")
+				So(output, ShouldContainSubstring, "Size (total/recently uploaded/recently removed): 3 B / 1 B / 0 B")
+				So(output, ShouldContainSubstring, setFileToBeDeleted)
+			})
 
 			Convey("sync with --delete uploads new files and deletes locally deleted ones", func() {
 				exitCode, _ = s.runBinary(t, "sync", "--name", setName, "--delete")

--- a/server/client.go
+++ b/server/client.go
@@ -236,19 +236,19 @@ func (c *Client) MergeDirs(setID string, paths []string) error {
 // for the given set, and now want it to discover the files that exist and
 // discover the contents of the directories, and start the process of backing up
 // the files.
-func (c *Client) TriggerDiscovery(setID string) error {
-	resp, err := c.request().Get(EndPointAuthDiscovery + "/" + setID)
-	if err != nil {
-		return err
+//
+// This will delete remote files missing locally if the set has monitor-removals
+// turned on, or if the force_removals parameter is passed as true.
+func (c *Client) TriggerDiscovery(setID string, forceRemovals ...bool) error {
+	var fr bool
+
+	if len(forceRemovals) == 1 {
+		fr = forceRemovals[0]
 	}
 
-	return responseToErr(resp)
-}
+	endpoint := fmt.Sprintf("%s/%s?force_removals=%t", EndPointAuthDiscovery, setID, fr)
 
-// SyncWithDeletion starts the process of doing a one-time upload of files
-// missing remotely or changed locally and delete remote files missing locally
-func (c *Client) SyncWithDeletion(setID string) error {
-	resp, err := c.request().Get(EndPointAuthSyncWithDeletion + "/" + setID)
+	resp, err := c.request().Get(endpoint)
 	if err != nil {
 		return err
 	}

--- a/server/client.go
+++ b/server/client.go
@@ -245,6 +245,17 @@ func (c *Client) TriggerDiscovery(setID string) error {
 	return responseToErr(resp)
 }
 
+// SyncWithDeletion starts the process of doing a one-time upload of files
+// missing remotely or changed locally and delete remote files missing locally
+func (c *Client) SyncWithDeletion(setID string) error {
+	resp, err := c.request().Get(EndPointAuthSyncWithDeletion + "/" + setID)
+	if err != nil {
+		return err
+	}
+
+	return responseToErr(resp)
+}
+
 // GetFiles gets the defined and discovered file paths and their backup status
 // for the given set.
 func (c *Client) GetFiles(setID string) ([]*set.Entry, error) {

--- a/server/client.go
+++ b/server/client.go
@@ -239,14 +239,8 @@ func (c *Client) MergeDirs(setID string, paths []string) error {
 //
 // This will delete remote files missing locally if the set has monitor-removals
 // turned on, or if the force_removals parameter is passed as true.
-func (c *Client) TriggerDiscovery(setID string, forceRemovals ...bool) error {
-	var fr bool
-
-	if len(forceRemovals) == 1 {
-		fr = forceRemovals[0]
-	}
-
-	endpoint := fmt.Sprintf("%s/%s?force_removals=%t", EndPointAuthDiscovery, setID, fr)
+func (c *Client) TriggerDiscovery(setID string, forceRemovals bool) error {
+	endpoint := fmt.Sprintf("%s/%s?force_removals=%t", EndPointAuthDiscovery, setID, forceRemovals)
 
 	resp, err := c.request().Get(endpoint)
 	if err != nil {

--- a/server/discover.go
+++ b/server/discover.go
@@ -208,9 +208,9 @@ func (s *Server) triggerDiscovery(c *gin.Context) {
 // followed by adding all upload requests for the set to the global put queue.
 //
 // The optional forceRemovals bool, if true, makes this behave as if the set has
-// MonitorRemovals true, to force deletion of files in iRODS if the corresonding
+// MonitorRemovals true, to force deletion of files in iRODS if the corresponding
 // local file no longer exists.
-func (s *Server) discoverSet(given *set.Set, forceRemovals ...bool) error {
+func (s *Server) discoverSet(given *set.Set, forceRemovals bool) error {
 	if given.ReadOnly {
 		s.Logger.Printf("Ignore discovery on a read-only set %s [%s:%s]", given.ID(), given.Requester, given.Name)
 
@@ -224,13 +224,7 @@ func (s *Server) discoverSet(given *set.Set, forceRemovals ...bool) error {
 		return err
 	}
 
-	var fr bool
-
-	if len(forceRemovals) == 1 {
-		fr = forceRemovals[0]
-	}
-
-	go s.discoverThenEnqueue(given, transformer, fr)
+	go s.discoverThenEnqueue(given, transformer, forceRemovals)
 
 	return nil
 }

--- a/server/discover.go
+++ b/server/discover.go
@@ -697,8 +697,15 @@ func (s *Server) syncWithDeletion(c *gin.Context) {
 	}
 
 	go func() {
-		if err := s.discoverSetRemovals(givenSet); err != nil {
-			s.recordSetError("error discovering set (%s) removals: %s", givenSet.ID(), err)
+		monitorRemoval := givenSet.MonitorRemovals
+		givenSet.MonitorRemovals = true
+		err := s.discoverSet(givenSet)
+		givenSet.MonitorRemovals = monitorRemoval
+
+		if err != nil {
+			s.Logger.Printf("discovery error %s: %s", givenSet.ID(), err)
+
+			return
 		}
 	}()
 

--- a/server/server.go
+++ b/server/server.go
@@ -176,7 +176,7 @@ func New(conf Config) (*Server, error) { //nolint:funlen
 }
 
 func (s *Server) monitorCB(given *set.Set) {
-	if err := s.discoverSet(given); err != nil {
+	if err := s.discoverSet(given, false); err != nil {
 		s.Logger.Printf("error discovering set during monitoring: %s", err)
 	}
 }

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -369,7 +369,7 @@ func TestServer(t *testing.T) {
 						err = client.AddOrUpdateSet(exampleSet)
 						So(err, ShouldBeNil)
 
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -463,7 +463,7 @@ func TestServer(t *testing.T) {
 							err = client.AddOrUpdateSet(exampleSet)
 							So(err, ShouldBeNil)
 
-							err = client.TriggerDiscovery(exampleSet.ID())
+							err = client.TriggerDiscovery(exampleSet.ID(), false)
 							So(err, ShouldBeNil)
 
 							ok := <-racCalled
@@ -528,7 +528,7 @@ func TestServer(t *testing.T) {
 						err = client.MergeDirs(exampleSet.ID(), []string{dir1local})
 						So(err, ShouldBeNil)
 
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -669,7 +669,7 @@ func TestServer(t *testing.T) {
 									err = client.MergeDirs(exampleSet2.ID(), []string{dir1local})
 									So(err, ShouldBeNil)
 
-									err = client.TriggerDiscovery(exampleSet2.ID())
+									err = client.TriggerDiscovery(exampleSet2.ID(), false)
 									So(err, ShouldBeNil)
 
 									ok := <-racCalled
@@ -814,7 +814,7 @@ func TestServer(t *testing.T) {
 									So(err, ShouldBeNil)
 								}
 
-								err = client.TriggerDiscovery(exampleSet.ID())
+								err = client.TriggerDiscovery(exampleSet.ID(), false)
 								So(err, ShouldBeNil)
 
 								ok := <-racCalled
@@ -835,7 +835,7 @@ func TestServer(t *testing.T) {
 							So(dirs, ShouldHaveLength, 2)
 
 							Convey("You can still see original files and folders after rediscovery", func() {
-								err = client.TriggerDiscovery(exampleSet.ID())
+								err = client.TriggerDiscovery(exampleSet.ID(), false)
 								So(err, ShouldBeNil)
 
 								files, errg := client.GetFiles(exampleSet.ID())
@@ -864,7 +864,7 @@ func TestServer(t *testing.T) {
 						err = client.MergeDirs(exampleSet.ID(), []string{dir1})
 						So(err, ShouldBeNil)
 
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -918,7 +918,7 @@ func TestServer(t *testing.T) {
 						err = client.MergeDirs(exampleSet.ID(), []string{dir1})
 						So(err, ShouldBeNil)
 
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -950,7 +950,7 @@ func TestServer(t *testing.T) {
 								fileToBeDiscovered := filepath.Join(dir1, "file"+strconv.Itoa(filesInSet+1))
 								internal.CreateTestFile(t, fileToBeDiscovered, "file content")
 
-								err = client.TriggerDiscovery(exampleSet.ID())
+								err = client.TriggerDiscovery(exampleSet.ID(), false)
 								So(err, ShouldBeNil)
 
 								ok = <-racCalled
@@ -1035,7 +1035,7 @@ func TestServer(t *testing.T) {
 						slackWriter.Reset()
 
 						tn := time.Now()
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -1093,7 +1093,7 @@ func TestServer(t *testing.T) {
 
 						tn = time.Now()
 
-						err = client.TriggerDiscovery(exampleSet2.ID())
+						err = client.TriggerDiscovery(exampleSet2.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok = <-racCalled
@@ -1122,7 +1122,7 @@ func TestServer(t *testing.T) {
 
 						tn = time.Now()
 
-						err = client.TriggerDiscovery(exampleSet3.ID())
+						err = client.TriggerDiscovery(exampleSet3.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok = <-racCalled
@@ -1140,7 +1140,8 @@ func TestServer(t *testing.T) {
 						So(gotSet.NumFiles, ShouldEqual, len(discovers))
 
 						So(racCalls, ShouldEqual, 3)
-						err = client.TriggerDiscovery(exampleSet.ID())
+
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						<-time.After(100 * time.Millisecond)
@@ -1548,7 +1549,7 @@ func TestServer(t *testing.T) {
 							err = client.MergeDirs(emptySet.ID(), []string{emptyDir})
 							So(err, ShouldBeNil)
 
-							err = client.TriggerDiscovery(emptySet.ID())
+							err = client.TriggerDiscovery(emptySet.ID(), false)
 							So(err, ShouldBeNil)
 
 							<-time.After(100 * time.Millisecond)
@@ -1609,7 +1610,7 @@ func TestServer(t *testing.T) {
 
 								So(err, ShouldBeNil)
 
-								err = client.TriggerDiscovery(emptySet.ID())
+								err = client.TriggerDiscovery(emptySet.ID(), false)
 								So(err, ShouldBeNil)
 
 								gotSet, err = client.GetSetByID(emptySet.Requester, emptySet.ID())
@@ -1634,7 +1635,7 @@ func TestServer(t *testing.T) {
 								err = client.AddOrUpdateSet(changedSet)
 								So(err, ShouldBeNil)
 
-								err = client.TriggerDiscovery(emptySet.ID())
+								err = client.TriggerDiscovery(emptySet.ID(), false)
 								So(err, ShouldBeNil)
 
 								<-time.After(10 * time.Millisecond)
@@ -2103,7 +2104,7 @@ func TestServer(t *testing.T) {
 							err = client.MergeDirs(exampleSet.ID(), []string{dir})
 							So(err, ShouldBeNil)
 
-							err = client.TriggerDiscovery(exampleSet.ID())
+							err = client.TriggerDiscovery(exampleSet.ID(), false)
 							So(err, ShouldBeNil)
 
 							tsCh := make(chan time.Time, 1)
@@ -2187,7 +2188,7 @@ func TestServer(t *testing.T) {
 						err = client.AddOrUpdateSet(exampleSet)
 						So(err, ShouldBeNil)
 
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -2312,7 +2313,7 @@ func TestServer(t *testing.T) {
 
 						discovered := gotSet.LastDiscovery
 
-						err = client.TriggerDiscovery(gotSet.ID())
+						err = client.TriggerDiscovery(gotSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						gotSet, err = client.GetSetByID(gotSet.Requester, gotSet.ID())
@@ -2326,7 +2327,7 @@ func TestServer(t *testing.T) {
 
 						logWriter.Reset()
 
-						err = client.TriggerDiscovery(gotSet.ID())
+						err = client.TriggerDiscovery(gotSet.ID(), false)
 						So(err, ShouldBeNil)
 						So(logWriter.String(), ShouldContainSubstring, "Ignore discovery")
 
@@ -2366,7 +2367,7 @@ func TestServer(t *testing.T) {
 
 						slackWriter.Reset()
 
-						err = client.TriggerDiscovery(badSet.ID())
+						err = client.TriggerDiscovery(badSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						<-time.After(300 * time.Millisecond)
@@ -2478,7 +2479,7 @@ func TestServer(t *testing.T) {
 					So(gotSet.Status, ShouldEqual, set.PendingDiscovery)
 					So(gotSet.NumFiles, ShouldEqual, 0)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -2694,7 +2695,7 @@ func TestServer(t *testing.T) {
 							internal.CreateTestFileOfLength(t, newFile, 2)
 							expectedNumFiles := len(discovers) + 1
 
-							err = client.TriggerDiscovery(exampleSet.ID())
+							err = client.TriggerDiscovery(exampleSet.ID(), false)
 							So(err, ShouldBeNil)
 
 							ok := <-racCalled
@@ -2804,7 +2805,7 @@ func TestServer(t *testing.T) {
 							err = os.Rename(renamed, discovers[0])
 							So(err, ShouldBeNil)
 
-							err = client.TriggerDiscovery(exampleSet.ID())
+							err = client.TriggerDiscovery(exampleSet.ID(), false)
 							So(err, ShouldBeNil)
 
 							ok := <-racCalled
@@ -3097,7 +3098,7 @@ func TestServer(t *testing.T) {
 							})
 
 							Convey("whereupon they can be manually retried even if the set gets re-discovered", func() {
-								err = client.TriggerDiscovery(exampleSet.ID())
+								err = client.TriggerDiscovery(exampleSet.ID(), false)
 								So(err, ShouldBeNil)
 
 								ok := <-racCalled
@@ -3284,7 +3285,7 @@ func TestServer(t *testing.T) {
 					err = client.MergeFiles(exampleSet.ID(), files)
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3311,7 +3312,7 @@ func TestServer(t *testing.T) {
 					err = s.db.RemoveFileEntry(exampleSet.ID(), dirs[0])
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok = <-racCalled
@@ -3354,7 +3355,7 @@ func TestServer(t *testing.T) {
 					So(len(entries), ShouldEqual, 1)
 					So([]byte(entries[0].Path), ShouldResemble, []byte(path))
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3383,7 +3384,7 @@ func TestServer(t *testing.T) {
 					So(entries[0].Path, ShouldEqual, fifoPath)
 					So(entries[1].Path, ShouldEqual, regPath)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3436,7 +3437,7 @@ func TestServer(t *testing.T) {
 					err = client.MergeDirs(exampleSet.ID(), []string{setDir})
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3465,7 +3466,7 @@ func TestServer(t *testing.T) {
 					err = client.MergeDirs(exampleSet.ID(), []string{dir})
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3530,7 +3531,7 @@ func TestServer(t *testing.T) {
 					err = client.MergeFiles(exampleSet.ID(), []string{pathToBackup})
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3595,7 +3596,7 @@ func TestServer(t *testing.T) {
 					err = client.MergeDirs(exampleSet.ID(), []string{setDir})
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3631,7 +3632,7 @@ func TestServer(t *testing.T) {
 					So(err, ShouldBeNil)
 
 					Convey("without remote hardlink location set, hardlinks upload multiple times", func() {
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -3677,7 +3678,7 @@ func TestServer(t *testing.T) {
 						hardlinksDir := filepath.Join(remoteDir, "mountpoints")
 						s.SetRemoteHardlinkLocation(hardlinksDir)
 
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok := <-racCalled
@@ -3727,7 +3728,7 @@ func TestServer(t *testing.T) {
 							So(err, ShouldBeNil)
 						}
 
-						err = client.TriggerDiscovery(exampleSet.ID())
+						err = client.TriggerDiscovery(exampleSet.ID(), false)
 						So(err, ShouldBeNil)
 
 						ok = <-racCalled
@@ -3836,7 +3837,7 @@ func TestServer(t *testing.T) {
 								err = client.MergeFiles(exampleSet.ID(), []string{path4, path5, path6})
 								So(err, ShouldBeNil)
 
-								err = client.TriggerDiscovery(exampleSet.ID())
+								err = client.TriggerDiscovery(exampleSet.ID(), false)
 								So(err, ShouldBeNil)
 
 								ok := <-racCalled
@@ -3892,7 +3893,7 @@ func TestServer(t *testing.T) {
 					err = client.MergeDirs(exampleSet.ID(), []string{hdir})
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3920,7 +3921,7 @@ func TestServer(t *testing.T) {
 					err = client.MergeDirs(exampleSet.ID(), []string{dir})
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok := <-racCalled
@@ -3933,7 +3934,7 @@ func TestServer(t *testing.T) {
 					err = client.AddOrUpdateSet(exampleSet)
 					So(err, ShouldBeNil)
 
-					err = client.TriggerDiscovery(exampleSet.ID())
+					err = client.TriggerDiscovery(exampleSet.ID(), false)
 					So(err, ShouldBeNil)
 
 					ok = <-racCalled

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -838,6 +838,8 @@ func TestServer(t *testing.T) {
 								err = client.TriggerDiscovery(exampleSet.ID(), false)
 								So(err, ShouldBeNil)
 
+								<-time.After(100 * time.Millisecond)
+
 								files, errg := client.GetFiles(exampleSet.ID())
 								So(errg, ShouldBeNil)
 								So(files, ShouldHaveLength, 2)

--- a/server/setdb.go
+++ b/server/setdb.go
@@ -50,22 +50,23 @@ import (
 )
 
 const (
-	setPath            = "/set"
-	filePath           = "/files"
-	dirPath            = "/dirs"
-	entryPath          = "/entries"
-	uploadedEntryPath  = "/uploaded_entries"
-	lastStateEntryPath = "/laststate_entries"
-	exampleEntryPath   = "/example_entries"
-	failedEntryPath    = "/failed_entries"
-	discoveryPath      = "/discover"
-	requestsPath       = "/requests"
-	workingPath        = "/working"
-	fileStatusPath     = "/file_status"
-	fileRetryPath      = "/retry"
-	removePathsPath    = "/remove_paths"
-	trashPathsPath     = "/trash_paths"
-	removeExpiredPath  = "/remove_expired"
+	setPath              = "/set"
+	filePath             = "/files"
+	dirPath              = "/dirs"
+	entryPath            = "/entries"
+	uploadedEntryPath    = "/uploaded_entries"
+	lastStateEntryPath   = "/laststate_entries"
+	exampleEntryPath     = "/example_entries"
+	failedEntryPath      = "/failed_entries"
+	discoveryPath        = "/discover"
+	syncWithDeletionPath = "/sync_with_deletion"
+	requestsPath         = "/requests"
+	workingPath          = "/working"
+	fileStatusPath       = "/file_status"
+	fileRetryPath        = "/retry"
+	removePathsPath      = "/remove_paths"
+	trashPathsPath       = "/trash_paths"
+	removeExpiredPath    = "/remove_expired"
 
 	// EndPointAuthSet is the endpoint for getting and setting sets.
 	EndPointAuthSet = gas.EndPointAuth + setPath
@@ -86,6 +87,11 @@ const (
 	// EndPointAuthLastStateEntries is the endpoint for getting uploaded entries
 	// excluding orphaned entries.
 	EndPointAuthLastStateEntries = gas.EndPointAuth + lastStateEntryPath
+
+	// EndPointSyncWithDeletion is the endpoint for one-time upload of files
+	// missing remotely or changed locally and delete remote files missing
+	// locally
+	EndPointAuthSyncWithDeletion = gas.EndPointAuth + syncWithDeletionPath
 
 	// EndPointAuthExampleEntry is the endpoint for getting set entries.
 	EndPointAuthExampleEntry = gas.EndPointAuth + exampleEntryPath
@@ -289,6 +295,8 @@ func (s *Server) addDBEndpoints(authGroup *gin.RouterGroup) { //nolint:funlen
 	idParam := "/:" + paramSetID
 
 	authGroup.GET(discoveryPath+idParam, s.triggerDiscovery)
+
+	authGroup.GET(syncWithDeletionPath+idParam, s.syncWithDeletion)
 
 	authGroup.GET(entryPath+idParam, s.getEntries)
 	authGroup.GET(uploadedEntryPath+idParam, s.getUploadedEntries)

--- a/server/setdb.go
+++ b/server/setdb.go
@@ -50,23 +50,22 @@ import (
 )
 
 const (
-	setPath              = "/set"
-	filePath             = "/files"
-	dirPath              = "/dirs"
-	entryPath            = "/entries"
-	uploadedEntryPath    = "/uploaded_entries"
-	lastStateEntryPath   = "/laststate_entries"
-	exampleEntryPath     = "/example_entries"
-	failedEntryPath      = "/failed_entries"
-	discoveryPath        = "/discover"
-	syncWithDeletionPath = "/sync_with_deletion"
-	requestsPath         = "/requests"
-	workingPath          = "/working"
-	fileStatusPath       = "/file_status"
-	fileRetryPath        = "/retry"
-	removePathsPath      = "/remove_paths"
-	trashPathsPath       = "/trash_paths"
-	removeExpiredPath    = "/remove_expired"
+	setPath            = "/set"
+	filePath           = "/files"
+	dirPath            = "/dirs"
+	entryPath          = "/entries"
+	uploadedEntryPath  = "/uploaded_entries"
+	lastStateEntryPath = "/laststate_entries"
+	exampleEntryPath   = "/example_entries"
+	failedEntryPath    = "/failed_entries"
+	discoveryPath      = "/discover"
+	requestsPath       = "/requests"
+	workingPath        = "/working"
+	fileStatusPath     = "/file_status"
+	fileRetryPath      = "/retry"
+	removePathsPath    = "/remove_paths"
+	trashPathsPath     = "/trash_paths"
+	removeExpiredPath  = "/remove_expired"
 
 	// EndPointAuthSet is the endpoint for getting and setting sets.
 	EndPointAuthSet = gas.EndPointAuth + setPath
@@ -88,11 +87,6 @@ const (
 	// excluding orphaned entries.
 	EndPointAuthLastStateEntries = gas.EndPointAuth + lastStateEntryPath
 
-	// EndPointSyncWithDeletion is the endpoint for one-time upload of files
-	// missing remotely or changed locally and delete remote files missing
-	// locally
-	EndPointAuthSyncWithDeletion = gas.EndPointAuth + syncWithDeletionPath
-
 	// EndPointAuthExampleEntry is the endpoint for getting set entries.
 	EndPointAuthExampleEntry = gas.EndPointAuth + exampleEntryPath
 
@@ -100,7 +94,11 @@ const (
 	// entries.
 	EndPointAuthFailedEntries = gas.EndPointAuth + failedEntryPath
 
-	// EndPointAuthDiscovery is the endpoint for triggering set discovery.
+	// EndPointAuthDiscovery is the endpoint for triggering set discovery which
+	// will ultimately result in the upload of files missing remotely or changed
+	// locally and will delete remote files missing locally if the set has
+	// monitor-removals turned on, or if the force_removals parameter is passed
+	// as true.
 	EndPointAuthDiscovery = gas.EndPointAuth + discoveryPath
 
 	// EndPointAuthRequests is the endpoint for getting file upload requests.
@@ -295,8 +293,6 @@ func (s *Server) addDBEndpoints(authGroup *gin.RouterGroup) { //nolint:funlen
 	idParam := "/:" + paramSetID
 
 	authGroup.GET(discoveryPath+idParam, s.triggerDiscovery)
-
-	authGroup.GET(syncWithDeletionPath+idParam, s.syncWithDeletion)
 
 	authGroup.GET(entryPath+idParam, s.getEntries)
 	authGroup.GET(uploadedEntryPath+idParam, s.getUploadedEntries)

--- a/server/setdb.go
+++ b/server/setdb.go
@@ -1958,7 +1958,7 @@ func (s *Server) recoverRemoveQueue() error {
 // middle of uploading; otherwise do nothing.
 func (s *Server) recoverSet(given *set.Set) error {
 	if given.StartedDiscovery.After(given.LastDiscovery) {
-		return s.discoverSet(given)
+		return s.discoverSet(given, false)
 	}
 
 	s.monitorSet(given)


### PR DESCRIPTION
Permanent removal to match monitored removals behaviour

 

The equivalent of running `edit --monitor-removals` and triggering discovery, waiting for it to to do any removals, then running `edit --stop-monitor-removals`

