### PR TITLE
Add otar transformer

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -46,7 +46,7 @@ const (
 	hoursInDay          = 24
 	hoursInWeek         = hoursInDay * 7
 	helpTextName        = "a short name for this backup set"
-	helpTextTransformer = "'humgen' | 'gengen' | 'prefix=local:remote'"
+	helpTextTransformer = "'humgen' | 'gengen' | 'otar' | 'prefix=local:remote'"
 	helpTextDescription = "a long description of this backup set"
 	helpTextFiles       = "path to file with one absolute local file path per line"
 	helpTextDirs        = "path to file with one absolute local directory path per line"
@@ -133,6 +133,7 @@ To describe the backup set you must provide:
       Human Genetics project or team folder, use this transformer to backup
 	  files to the canonical path in the iRODS humgen zone.
     'gengen' : like 'humgen', but for Generative Genomics data.
+	'otar'   : like 'humgen', but for Open Targets data.
     'prefix=local:remote' : replace 'local' with a local path prefix, and
 	  'remote' with a remote one, eg. 'prefix=/mnt/diska:/zone1' would backup
 	  /mnt/diska/subdir/file.txt to /zone1/subdir/file.txt.

--- a/main_test.go
+++ b/main_test.go
@@ -700,7 +700,7 @@ func TestList(t *testing.T) {
 
 				Convey("list returns an error", func() {
 					s.confirmOutput(t, []string{"list", "--name", "testAddFiles"}, 1,
-						"your transformer didn't work: not a valid humgen lustre path ["+
+						"your transformer didn't work: not a valid lustre path ["+
 							dir+"/path/to/other/file]")
 				})
 			})
@@ -1204,7 +1204,7 @@ Num files: 0; Symlinks: 0; Hardlinks: 0; Size (total/recently uploaded/recently 
 Uploaded: 0; Replaced: 0; Skipped: 0; Failed: 0; Missing: 0; Orphaned: 0; Abnormal: 0
 Completed in: 0s
 Directories:
-your transformer didn't work: not a valid humgen lustre path [` + localDir + `/file.txt]
+your transformer didn't work: not a valid lustre path [` + localDir + `/file.txt]
   ` + localDir
 
 			s.confirmOutput(t, []string{"status", "-n", "badHumgen"}, 0, expected)

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -2380,7 +2380,7 @@ func TestServer(t *testing.T) {
 						So(gotSet.Error, ShouldNotBeNil)
 						So(slackWriter.String(), ShouldEqual,
 							fmt.Sprintf(slack.BoxPrefixInfo+"`jim.setbad` completed discovery: 4 files"+
-								slack.BoxPrefixError+"`jim.setbad` is invalid: not a valid humgen lustre path [%s]", expected[0]))
+								slack.BoxPrefixError+"`jim.setbad` is invalid: not a valid lustre path [%s]", expected[0]))
 
 						err = dfunc()
 						So(err, ShouldBeNil)
@@ -2397,10 +2397,10 @@ func TestServer(t *testing.T) {
 						}()
 
 						So(logWriter.String(), ShouldEqual, fmt.Sprintf("failed to recover set setbad for jim: "+
-							"not a valid humgen lustre path [%s]\n", expected[0]))
+							"not a valid lustre path [%s]\n", expected[0]))
 						So(slackWriter.String(), ShouldEqual, fmt.Sprintf(serverStartMessage+
 							slack.BoxPrefixError+"`jim.setbad` could not be recovered: "+
-							"not a valid humgen lustre path [%s]"+serverRecoveryMessage+serverStartedMessage, expected[0]))
+							"not a valid lustre path [%s]"+serverRecoveryMessage+serverStartedMessage, expected[0]))
 					})
 
 					Convey("And if you make the set read-only", func() {

--- a/set/set.go
+++ b/set/set.go
@@ -337,6 +337,10 @@ func (s *Set) MakeTransformer() (transfer.PathTransformer, error) {
 		return transfer.GengenTransformer, nil
 	}
 
+	if s.Transformer == "otar" {
+		return transfer.OpentargetsTransformer, nil
+	}
+
 	if !strings.HasPrefix(s.Transformer, prefixTransformerKey) {
 		return nil, Error{ErrInvalidTransformer, ""}
 	}

--- a/transfer/request.go
+++ b/transfer/request.go
@@ -56,12 +56,12 @@ const (
 	RequestStatusFailed          RequestStatus = "failed"
 	RequestStatusWarning         RequestStatus = "warning"
 	RequestStatusHardlinkSkipped RequestStatus = "hardlink"
-	ErrNotHumgenLustre                         = "not a valid humgen lustre path"
+	ErrNotHumgenLustre                         = "not a valid lustre path"
 	stuckTimeFormat                            = "02/01/06 15:04 MST"
 	defaultDirPerms                            = 0777
 )
 
-var genTransformerRegex = regexp.MustCompile(`^/lustre/(scratch[^/]+)(/[^/]*)+?/(projects|teams|users)(_v2)?/([^/]+)/`)
+var genTransformerRegex = regexp.MustCompile(`^/lustre/(scratch[^/]+)(/[^/]*)+?/([Pp]rojects|teams|users)(_v2)?/([^/]+)/`) //nolint:lll
 
 // Stuck is used to provide details of a potentially "stuck" upload Request.
 type Stuck struct {
@@ -510,4 +510,19 @@ func GengenTransformer(local string) (string, error) {
 	}
 
 	return strings.Replace(humgenPath, "/humgen", "/humgen/gengen", 1), nil
+}
+
+// OpentargetsTransformer is a PathTransformer that will convert a local
+// "lustre" path to a "canonical" path in the humgen iRODS zone, for the
+// OpenTargets BoM.
+//
+// This transform is specific to the "opentargets" group at the Sanger
+// Institute.
+func OpentargetsTransformer(local string) (string, error) {
+	humgenPath, err := HumgenTransformer(local)
+	if err != nil {
+		return "", err
+	}
+
+	return strings.Replace(humgenPath, "/humgen", "/humgen/open-targets", 1), nil
 }

--- a/transfer/request_test.go
+++ b/transfer/request_test.go
@@ -180,6 +180,30 @@ func TestRequest(t *testing.T) {
 		}
 	})
 
+	Convey("You can make new requests using the opentargets transform", t, func() {
+		r, err := NewRequestWithTransformedLocal("/lustre/scratch117/casm/team78/so11/file.txt", OpentargetsTransformer)
+		So(err, ShouldNotBeNil)
+		So(r, ShouldBeNil)
+
+		r, err = NewRequestWithTransformedLocal("file.txt", OpentargetsTransformer)
+		So(err, ShouldNotBeNil)
+		So(r, ShouldBeNil)
+
+		locals := []string{
+			"/lustre/scratch127/open-targets/Projects/OTAR2064/file.txt",
+		}
+
+		expected := []string{
+			"/humgen/open-targets/Projects/OTAR2064/scratch127/file.txt",
+		}
+
+		for i, local := range locals {
+			r, err = NewRequestWithTransformedLocal(local, OpentargetsTransformer)
+			So(err, ShouldBeNil)
+			So(r.Remote, ShouldEqual, expected[i])
+		}
+	})
+
 	Convey("You can create and stringify Stucks", t, func() {
 		n := time.Now()
 		s := NewStuck(n)


### PR DESCRIPTION
This is a quick hack to get otar transformer in due to user urgency, because HSI-167 branch (where transformers are defined in a config file) was taking too long.

No tests added to main for this because the full test needs an actual file in an otar directory, which we don't have permission to create, and again, this is a quick hack. Tested manually as far as was possible without perms.