### PR TITLE
Delete file before retry on bad replica

### DIFF
--- a/internal/mock.go
+++ b/internal/mock.go
@@ -40,25 +40,38 @@ import (
 )
 
 const ErrMockStatFail = "stat fail"
+
 const ErrMockPutFail = "put fail"
+
 const ErrMockMetaFail = "meta fail"
+
 const ErrFileDoesNotExist = "file does not exist"
+
+const defaultGoodReplicaCount = 2
+
+type replicaCount struct {
+	good int
+	bad  int
+}
 
 // LocalHandler satisfies the Handler interface, treating "Remote" as local
 // paths and moving from Local to Remote for the Put().
 type LocalHandler struct {
-	Connected   bool
-	Cleaned     bool
-	Collections []string
-	Meta        map[string]map[string]string
-	statFail    string
-	putFail     string
-	putSlow     string
-	putDur      time.Duration
-	metaFail    string
-	removeSlow  bool
-	addMetaSlow bool
-	mu          sync.RWMutex
+	Connected             bool
+	Cleaned               bool
+	Collections           []string
+	Meta                  map[string]map[string]string
+	RemovedFiles          []string
+	statFail              string
+	putFail               string
+	putFailIfRemoteExists string
+	putSlow               string
+	putDur                time.Duration
+	metaFail              string
+	removeSlow            bool
+	addMetaSlow           bool
+	replicaCounts         map[string]replicaCount
+	mu                    sync.RWMutex
 }
 
 // GetLocalHandler returns a Handler that doesn't actually interact with iRODS,
@@ -66,7 +79,8 @@ type LocalHandler struct {
 // Remote for any Put()s. For use during tests.
 func GetLocalHandler() *LocalHandler {
 	return &LocalHandler{
-		Meta: make(map[string]map[string]string),
+		Meta:          make(map[string]map[string]string),
+		replicaCounts: make(map[string]replicaCount),
 	}
 }
 
@@ -141,6 +155,12 @@ func (l *LocalHandler) MakePutFail(remote string) {
 	l.putFail = remote
 }
 
+// MakePutFailOnExistingRemote will result in any subsequent Put()s for the
+// given remote path failing only while that remote already exists.
+func (l *LocalHandler) MakePutFailOnExistingRemote(remote string) {
+	l.putFailIfRemoteExists = remote
+}
+
 // MakePutSlow will result in any subsequent Put()s for a Request with the
 // given local path taking the given amount of time.
 func (l *LocalHandler) MakePutSlow(remote string, dur time.Duration) {
@@ -166,11 +186,24 @@ func (l *LocalHandler) Put(local, remote string) error {
 		return errs.PathError{Msg: ErrMockPutFail, Path: ""}
 	}
 
+	if l.putFailIfRemoteExists == remote {
+		if _, err := os.Stat(remote); err == nil {
+			return errs.PathError{Msg: ErrMockPutFail, Path: ""}
+		}
+	}
+
 	if l.putSlow == remote {
 		<-time.After(l.putDur)
 	}
 
-	return copyFile(local, remote)
+	err := copyFile(local, remote)
+	if err == nil {
+		l.mu.Lock()
+		l.replicaCounts[remote] = replicaCount{good: defaultGoodReplicaCount}
+		l.mu.Unlock()
+	}
+
+	return err
 }
 
 func (l *LocalHandler) Get(local, remote string) error {
@@ -327,6 +360,35 @@ func doesMetaContainMeta(sourceMeta, targetMeta map[string]string) bool {
 	return valid
 }
 
+// SetReplicaCounts configures the returned good/bad replica counts for a path.
+func (l *LocalHandler) SetReplicaCounts(path string, good, bad int) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	l.replicaCounts[path] = replicaCount{good: good, bad: bad}
+}
+
+// ReplicaCounts returns configured good/bad replica counts for a path.
+func (l *LocalHandler) ReplicaCounts(path string) (bool, int, int, error) {
+	l.mu.RLock()
+	counts, ok := l.replicaCounts[path]
+	l.mu.RUnlock()
+
+	if ok {
+		return true, counts.good, counts.bad, nil
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		if os.IsNotExist(err) {
+			return false, 0, 0, nil
+		}
+
+		return false, 0, 0, err
+	}
+
+	return true, 1, 0, nil
+}
+
 // RemoveDir removes the empty dir.
 func (l *LocalHandler) RemoveDir(path string) error {
 	if l.removeSlow {
@@ -347,7 +409,11 @@ func (l *LocalHandler) RemoveFile(path string) error {
 		time.Sleep(1 * time.Second)
 	}
 
+	l.RemovedFiles = append(l.RemovedFiles, path)
 	delete(l.Meta, path)
+	l.mu.Lock()
+	delete(l.replicaCounts, path)
+	l.mu.Unlock()
 
 	err := os.Remove(path)
 	if err != nil && strings.Contains(err.Error(), "no such file or directory") {

--- a/server/discover.go
+++ b/server/discover.go
@@ -591,7 +591,7 @@ func (s *Server) enqueueSetFiles(given *set.Set, transformer transformer.PathTra
 		return false, err
 	}
 
-	return s.enqueueEntries(entries, given, transformer)
+	return s.enqueueEntries(entries, given, transformer, false)
 }
 
 // enqueueEntries converts the given entries to requests, stores those in items
@@ -599,7 +599,11 @@ func (s *Server) enqueueSetFiles(given *set.Set, transformer transformer.PathTra
 //
 // Returns true if only some of the items were added to the queue due to
 // reaching the queue limit.
-func (s *Server) enqueueEntries(entries []*set.Entry, given *set.Set, transformer transformer.PathTransformer) (bool, error) { //nolint:gocognit,lll,funlen
+//
+//nolint:gocognit,lll,funlen
+func (s *Server) enqueueEntries(entries []*set.Entry, given *set.Set,
+	transformer transformer.PathTransformer, retrying bool,
+) (bool, error) {
 	queueSpaceLeft := max(int(s.maxQueueLength)-s.queue.Stats().Items, 0) //nolint:gosec
 	defs := make([]*queue.ItemDef, min(len(entries), queueSpaceLeft))
 	hitLimit := queueSpaceLeft < len(entries)
@@ -617,7 +621,7 @@ func (s *Server) enqueueEntries(entries []*set.Entry, given *set.Set, transforme
 	}
 
 	for i, entry := range entries {
-		r, err := s.entryToRequest(entry, transformer, given)
+		r, err := s.entryToRequest(entry, transformer, given, retrying)
 		if err != nil {
 			return false, err
 		}
@@ -655,7 +659,7 @@ func (s *Server) enqueueEntries(entries []*set.Entry, given *set.Set, transforme
 // entryToRequest converts an Entry to a Request containing details of the given
 // set.
 func (s *Server) entryToRequest(entry *set.Entry, transformer transformer.PathTransformer,
-	given *set.Set,
+	given *set.Set, retrying bool,
 ) (*transfer.Request, error) {
 	r, err := transfer.NewRequestWithTransformedLocal(entry.Path, transformer)
 	if err != nil {
@@ -668,6 +672,7 @@ func (s *Server) entryToRequest(entry *set.Entry, transformer transformer.PathTr
 
 	r.Set = given.Name
 	r.Requester = given.Requester
+	r.Retrying = retrying
 
 	if entry.Type == set.Symlink {
 		r.Symlink = entry.Dest

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -55,6 +55,7 @@ import (
 	"github.com/wtsi-hgi/ibackup/set"
 	"github.com/wtsi-hgi/ibackup/slack"
 	"github.com/wtsi-hgi/ibackup/transfer"
+	"github.com/wtsi-hgi/ibackup/transformer"
 	btime "github.com/wtsi-ssg/wr/backoff/time"
 	"github.com/wtsi-ssg/wr/retry"
 )
@@ -286,6 +287,148 @@ func TestDetermineQueueSize(t *testing.T) {
 		So(size, ShouldBeGreaterThan, 0)
 		So(size, ShouldBeLessThan, 1<<32)
 	})
+}
+
+func TestEnqueueEntriesDoesNotMarkRetrying(t *testing.T) {
+	Convey("Ordinary enqueue of failed entries does not mark requests as retrying", t, func() {
+		logWriter := gas.NewStringLogger()
+		s, err := New(Config{
+			HTTPLogger:     logWriter,
+			ReadOnly:       true,
+			MaxQueueLength: 1,
+		})
+		So(err, ShouldBeNil)
+
+		localDir := t.TempDir()
+		remoteDir := t.TempDir()
+		given := &set.Set{
+			Name:        "set1",
+			Requester:   "jim",
+			Transformer: "prefix=" + localDir + ":" + remoteDir,
+			Metadata:    map[string]string{"project": "alpha"},
+		}
+
+		transform, err := given.MakeTransformer()
+		So(err, ShouldBeNil)
+
+		entry := &set.Entry{
+			Path:     filepath.Join(localDir, "failed.txt"),
+			Status:   set.Failed,
+			Attempts: 2,
+		}
+
+		request, err := s.entryToRequest(entry, transform, given, false)
+		So(err, ShouldBeNil)
+		So(request.Retrying, ShouldBeFalse)
+		So(request.Requester, ShouldEqual, given.Requester)
+		So(request.Set, ShouldEqual, given.Name)
+		So(request.Meta.LocalMeta["project"], ShouldEqual, "alpha")
+
+		hitLimit, err := s.enqueueEntries([]*set.Entry{entry}, given, transform, false)
+		So(err, ShouldBeNil)
+		So(hitLimit, ShouldBeFalse)
+
+		item, err := s.queue.Get(request.ID())
+		So(err, ShouldBeNil)
+
+		queuedRequest, ok := item.Data().(*transfer.Request)
+		So(ok, ShouldBeTrue)
+		So(queuedRequest.Retrying, ShouldBeFalse)
+		So(queuedRequest.Requester, ShouldEqual, given.Requester)
+		So(queuedRequest.Set, ShouldEqual, given.Name)
+		So(queuedRequest.Meta.LocalMeta["project"], ShouldEqual, "alpha")
+	})
+}
+
+func TestRetryFailedSetFilesMarksRequestsRetrying(t *testing.T) {
+	Convey("Explicit retry updates queued failed requests to retrying", t, func() {
+		s, given, entry, transform := setupFailedRetryEntryTest(t)
+
+		_, err := s.enqueueEntries([]*set.Entry{entry}, given, transform, false)
+		So(err, ShouldBeNil)
+
+		request, err := s.entryToRequest(entry, transform, given, false)
+		So(err, ShouldBeNil)
+
+		item, err := s.queue.Get(request.ID())
+		So(err, ShouldBeNil)
+
+		queuedRequest, ok := item.Data().(*transfer.Request)
+		So(ok, ShouldBeTrue)
+		So(queuedRequest.Retrying, ShouldBeFalse)
+
+		failed, err := s.retryFailedSetFiles(given)
+		So(err, ShouldBeNil)
+		So(failed, ShouldEqual, 1)
+
+		item, err = s.queue.Get(request.ID())
+		So(err, ShouldBeNil)
+
+		queuedRequest, ok = item.Data().(*transfer.Request)
+		So(ok, ShouldBeTrue)
+		So(queuedRequest.Retrying, ShouldBeTrue)
+	})
+}
+
+func setupFailedRetryEntryTest(t *testing.T) (*Server, *set.Set, *set.Entry, transformer.PathTransformer) {
+	t.Helper()
+
+	logWriter := gas.NewStringLogger()
+	s, err := New(Config{
+		HTTPLogger:     logWriter,
+		MaxQueueLength: 1,
+	})
+	So(err, ShouldBeNil)
+
+	db, err := set.New(createDBLocation(t), "", false)
+	So(err, ShouldBeNil)
+
+	s.db = db
+
+	localDir := t.TempDir()
+	remoteDir := t.TempDir()
+	localPath := filepath.Join(localDir, "failed.txt")
+
+	err = os.WriteFile(localPath, []byte("failed"), 0600)
+	So(err, ShouldBeNil)
+
+	given := &set.Set{
+		Name:        "set1",
+		Requester:   "jim",
+		Transformer: "prefix=" + localDir + ":" + remoteDir,
+	}
+
+	err = s.db.AddOrUpdate(given)
+	So(err, ShouldBeNil)
+	err = s.db.MergeFileEntries(given.ID(), []string{localPath})
+	So(err, ShouldBeNil)
+
+	_, err = s.db.Discover(given.ID(), nil)
+	So(err, ShouldBeNil)
+
+	failedRequest := &transfer.Request{
+		Local:     localPath,
+		Remote:    filepath.Join(remoteDir, "failed.txt"),
+		Requester: given.Requester,
+		Set:       given.Name,
+		Status:    transfer.RequestStatusFailed,
+		Error:     "boom",
+	}
+
+	_, err = s.db.SetEntryStatus(failedRequest)
+	So(err, ShouldBeNil)
+	_, err = s.db.SetEntryStatus(failedRequest)
+	So(err, ShouldBeNil)
+
+	transform, err := given.MakeTransformer()
+	So(err, ShouldBeNil)
+
+	entry, err := s.db.GetFileEntryForSet(given.ID(), localPath)
+	So(err, ShouldBeNil)
+	So(entry.Status, ShouldEqual, set.Failed)
+	So(entry.Attempts, ShouldEqual, 2)
+
+	return s, given, entry, transform
 }
 
 func TestServer(t *testing.T) {

--- a/server/setdb.go
+++ b/server/setdb.go
@@ -2192,13 +2192,16 @@ func (s *Server) retryFailedSetFiles(given *set.Set) (int, error) {
 	// those that aren't already present.
 	toEnqueue := make([]*set.Entry, 0, len(filtered))
 	for _, entry := range filtered {
-		r, errr := s.entryToRequest(entry, transformer, given)
+		r, errr := s.entryToRequest(entry, transformer, given, true)
 		if errr != nil {
 			return 0, errr
 		}
 
 		// If the request already exists, make it runnable immediately.
 		present := false
+
+		s.updateQueueItemData(r)
+
 		if errd := s.queue.SetDelay(r.ID(), 0); errd == nil {
 			present = true
 		}
@@ -2212,7 +2215,7 @@ func (s *Server) retryFailedSetFiles(given *set.Set) (int, error) {
 		}
 	}
 
-	_, err = s.enqueueEntries(toEnqueue, given, transformer)
+	_, err = s.enqueueEntries(toEnqueue, given, transformer, true)
 
 	return len(filtered), err
 }

--- a/transfer/put.go
+++ b/transfer/put.go
@@ -40,6 +40,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/wtsi-hgi/ibackup/baton/meta"
 	"github.com/wtsi-hgi/ibackup/errs"
+	"github.com/wtsi-hgi/ibackup/internal"
 	"github.com/wtsi-hgi/ibackup/statter"
 )
 
@@ -58,6 +59,7 @@ const (
 	// WorkerPoolSizeCollections is the max number of concurrent collection
 	// creations we'll do during CreateCollections().
 	WorkerPoolSizeCollections = 2
+	maxHealthyReplicaCount    = 2
 )
 
 // Handler is something that knows how to communicate with iRODS and carry out
@@ -104,6 +106,12 @@ type Handler interface {
 // provide best-effort replica counts for logging.
 type replicaCounter interface {
 	ReplicaCounts(remote string) (exists bool, good, bad int, err error)
+}
+
+// fileRemover is an optional interface that a Handler can implement to remove
+// a remote object prior to retrying an upload from scratch.
+type fileRemover interface {
+	RemoveFile(path string) error
 }
 
 // FileReadTester is a function that attempts to open and read the given path,
@@ -627,18 +635,90 @@ func (p *Putter) captureReplicaCounts(request *Request, goodDest, badDest **int)
 		return
 	}
 
-	rc, ok := p.handler.(replicaCounter)
-	if !ok {
-		return
-	}
-
-	exists, good, bad, err := rc.ReplicaCounts(request.RemoteDataPath())
-	if err != nil || !exists {
+	exists, good, bad, ok := p.replicaCounts(request)
+	if !ok || !exists {
 		return
 	}
 
 	*goodDest = &good
 	*badDest = &bad
+}
+
+func (p *Putter) replicaCounts(request *Request) (bool, int, int, bool) {
+	if request == nil {
+		return false, 0, 0, false
+	}
+
+	rc, ok := p.handler.(replicaCounter)
+	if !ok {
+		return false, 0, 0, false
+	}
+
+	exists, good, bad, err := rc.ReplicaCounts(request.RemoteDataPath())
+	if err != nil || !exists {
+		return exists, good, bad, false
+	}
+
+	return true, good, bad, true
+}
+
+func (p *Putter) shouldResetRemoteBeforeRetry(request *Request) bool {
+	if request == nil {
+		return false
+	}
+
+	if !request.Retrying {
+		return false
+	}
+
+	if should, known := shouldResetRemoteFromRecordedReplicaCounts(request); known {
+		return should
+	}
+
+	return p.shouldResetRemoteFromReplicaCounts(request)
+}
+
+func shouldResetRemoteFromRecordedReplicaCounts(request *Request) (bool, bool) {
+	if request.ReplicaBeforeBad != nil && *request.ReplicaBeforeBad > 0 {
+		return true, true
+	}
+
+	if request.ReplicaBeforeGood != nil || request.ReplicaBeforeBad != nil {
+		return replicaTotal(request.ReplicaBeforeGood, request.ReplicaBeforeBad) > maxHealthyReplicaCount, true
+	}
+
+	return false, false
+}
+
+func (p *Putter) shouldResetRemoteFromReplicaCounts(request *Request) bool {
+	exists, good, bad, ok := p.replicaCounts(request)
+	if !ok || !exists {
+		return false
+	}
+
+	if bad > 0 {
+		return true
+	}
+
+	return good+bad > maxHealthyReplicaCount
+}
+
+func (p *Putter) resetRemoteBeforeRetry(request *Request) error {
+	if !p.shouldResetRemoteBeforeRetry(request) {
+		return nil
+	}
+
+	remover, ok := p.handler.(fileRemover)
+	if !ok {
+		return nil
+	}
+
+	err := remover.RemoveFile(request.RemoteDataPath())
+	if err != nil && !errors.Is(err, errs.PathError{Msg: internal.ErrFileDoesNotExist}) {
+		return err
+	}
+
+	return nil
 }
 
 func (p *Putter) processPutCh(putCh, uploadStartCh, uploadReturnCh, metaCh chan *Request) {
@@ -660,6 +740,12 @@ func (p *Putter) processPutCh(putCh, uploadStartCh, uploadReturnCh, metaCh chan 
 		}
 
 		p.captureReplicaCounts(request, &request.ReplicaBeforeGood, &request.ReplicaBeforeBad)
+
+		if err := p.resetRemoteBeforeRetry(request); err != nil {
+			p.sendFailedRequest(request, err, uploadReturnCh)
+
+			continue
+		}
 
 		if err := p.transfer(request, p.handler); err != nil {
 			p.captureReplicaCounts(request, &request.ReplicaAfterGood, &request.ReplicaAfterBad)
@@ -687,6 +773,18 @@ func (p *Putter) testRead(request *Request) error {
 	}
 
 	return err
+}
+
+func replicaTotal(counts ...*int) int {
+	total := 0
+
+	for _, count := range counts {
+		if count != nil {
+			total += *count
+		}
+	}
+
+	return total
 }
 
 // headRead is a FileReadTester that uses the statter to read a byte.

--- a/transfer/put_test.go
+++ b/transfer/put_test.go
@@ -210,6 +210,61 @@ func TestPutMock(t *testing.T) {
 				}
 			})
 
+			Convey("Put() removes a corrupt remote object before retrying a replace", func() {
+				request := requests[1].Clone()
+				returned := uploadRetryingReplaceRequest(t, lh, request, true, 2, 1)
+				assertReplicaCounts(returned, 2, 1, 2, 0)
+			})
+
+			Convey("Put() removes an over-replicated remote object before retrying a replace", func() {
+				request := requests[1].Clone()
+				returned := uploadRetryingReplaceRequest(t, lh, request, true, 3, 0)
+				assertReplicaCounts(returned, 3, 0, 2, 0)
+			})
+
+			Convey("Put() removes a corrupt remote object before retrying a replace when replica logging is disabled", func() {
+				request := requests[1].Clone()
+				returned := uploadRetryingReplaceRequest(t, lh, request, false, 2, 1)
+				So(returned.ReplicaBeforeGood, ShouldBeNil)
+				So(returned.ReplicaBeforeBad, ShouldBeNil)
+				So(returned.ReplicaAfterGood, ShouldBeNil)
+				So(returned.ReplicaAfterBad, ShouldBeNil)
+			})
+
+			Convey("Put() removes an over-replicated remote object on retry when replica logging is disabled", func() {
+				request := requests[1].Clone()
+				returned := uploadRetryingReplaceRequest(t, lh, request, false, 3, 0)
+				So(returned.ReplicaBeforeGood, ShouldBeNil)
+				So(returned.ReplicaBeforeBad, ShouldBeNil)
+				So(returned.ReplicaAfterGood, ShouldBeNil)
+				So(returned.ReplicaAfterBad, ShouldBeNil)
+			})
+
+			Convey("Put() does not remove a remote object for a non-retrying replaced request", func() {
+				request := requests[1].Clone()
+				request.ReplicaLogging = true
+				request.Status = RequestStatusReplaced
+
+				remoteDir := filepath.Dir(request.Remote)
+				err = os.MkdirAll(remoteDir, 0o755)
+				So(err, ShouldBeNil)
+
+				err = os.WriteFile(request.Remote, []byte("stale"), 0o600)
+				So(err, ShouldBeNil)
+
+				lh.SetReplicaCounts(request.Remote, 2, 1)
+
+				p2 := &Putter{handler: lh}
+
+				err = p2.resetRemoteBeforeRetry(request)
+				So(err, ShouldBeNil)
+				So(lh.RemovedFiles, ShouldNotContain, request.Remote)
+
+				data, errr := os.ReadFile(request.Remote)
+				So(errr, ShouldBeNil)
+				So(string(data), ShouldEqual, "stale")
+			})
+
 			Convey("Put() uploads an empty file in place of links, with hardlink data going to the Hardlink location", func() {
 				err = os.Remove(requests[0].Local)
 				So(err, ShouldBeNil)
@@ -818,6 +873,65 @@ func TestPutNoReplace(t *testing.T) {
 	})
 }
 
+func uploadRetryingReplaceRequest(
+	t *testing.T,
+	lh *internal.LocalHandler,
+	request *Request,
+	replicaLogging bool,
+	goodReplicas, badReplicas int,
+) *Request {
+	t.Helper()
+
+	request.ReplicaLogging = replicaLogging
+	request.Retrying = true
+
+	remoteDir := filepath.Dir(request.Remote)
+	err := os.MkdirAll(remoteDir, 0o755)
+	So(err, ShouldBeNil)
+
+	err = os.WriteFile(request.Remote, []byte("stale"), 0o600)
+	So(err, ShouldBeNil)
+
+	touchFile(request.Local, time.Hour)
+	lh.SetReplicaCounts(request.Remote, goodReplicas, badReplicas)
+	lh.MakePutFailOnExistingRemote(request.Remote)
+
+	p, err := New(lh, []*Request{request})
+	So(err, ShouldBeNil)
+
+	uCh, urCh, srCh := p.Put()
+
+	uploading := 0
+	for range uCh {
+		uploading++
+	}
+
+	returned := make([]*Request, 0, 1)
+	for returnedRequest := range urCh {
+		returned = append(returned, returnedRequest)
+	}
+
+	skipped := 0
+	for range srCh {
+		skipped++
+	}
+
+	So(uploading, ShouldEqual, 1)
+	So(skipped, ShouldEqual, 0)
+	So(returned, ShouldHaveLength, 1)
+	So(returned[0].Status, ShouldEqual, RequestStatusReplaced)
+	So(lh.RemovedFiles, ShouldContain, request.Remote)
+
+	data, err := os.ReadFile(request.Remote)
+	So(err, ShouldBeNil)
+
+	expected, err := os.ReadFile(request.Local)
+	So(err, ShouldBeNil)
+	So(string(data), ShouldEqual, string(expected))
+
+	return returned[0]
+}
+
 // touchFile alters the mtime of the given file by the given duration. Returns
 // the time set.
 func touchFile(path string, d time.Duration) time.Time {
@@ -826,6 +940,17 @@ func touchFile(path string, d time.Duration) time.Time {
 	So(err, ShouldBeNil)
 
 	return newT
+}
+
+func assertReplicaCounts(request *Request, beforeGood, beforeBad, afterGood, afterBad int) {
+	So(request.ReplicaBeforeGood, ShouldNotBeNil)
+	So(*request.ReplicaBeforeGood, ShouldEqual, beforeGood)
+	So(request.ReplicaBeforeBad, ShouldNotBeNil)
+	So(*request.ReplicaBeforeBad, ShouldEqual, beforeBad)
+	So(request.ReplicaAfterGood, ShouldNotBeNil)
+	So(*request.ReplicaAfterGood, ShouldEqual, afterGood)
+	So(request.ReplicaAfterBad, ShouldNotBeNil)
+	So(*request.ReplicaAfterBad, ShouldEqual, afterBad)
 }
 
 // uploadRequests uploads the requests with the given handler and returns the

--- a/transfer/request.go
+++ b/transfer/request.go
@@ -103,6 +103,9 @@ type Request struct {
 	Set           string
 	Meta          *Meta
 	Status        RequestStatus
+	// Retrying is true when this request is re-attempting a previously failed
+	// upload.
+	Retrying bool
 	// ReplicaLogging is set by the server (and passed through to clients) to
 	// enable extra iRODS baton calls that determine replica counts before/after
 	// an upload.
@@ -265,6 +268,7 @@ func (r *Request) Clone() *Request {
 		Set:               r.Set,
 		Meta:              r.Meta,
 		Status:            r.Status,
+		Retrying:          r.Retrying,
 		ReplicaLogging:    r.ReplicaLogging,
 		ReplicaBeforeGood: r.ReplicaBeforeGood,
 		ReplicaBeforeBad:  r.ReplicaBeforeBad,

--- a/transfer/request_test.go
+++ b/transfer/request_test.go
@@ -252,6 +252,7 @@ func TestRequest(t *testing.T) {
 				Remote:            "/some/remote/path",
 				Requester:         "someRequester",
 				Set:               "testSet",
+				Retrying:          true,
 				ReplicaLogging:    true,
 				ReplicaBeforeGood: &replicaBeforeGood,
 				ReplicaBeforeBad:  &replicaBeforeBad,


### PR DESCRIPTION
When we run `ibackup server` or do manual `ibackup put` we sometimes get excess replicas generated in iRODS. There should only be 1 remote replica.
The cause can be (but might not be limited to) `SYS_COPY_LEN_ERR` failures when trying to replace a file previously successfully uploaded to iRODS, but now one of the resources is full, so the replace fails while a new excess replica is created, and the replicas no longer match each other. ibackup does not currently clean up bad replicas, and extendo/baton does not support itrim.

The solution is to:
- Detect we are in an upload retry state
- Check if we have more than 2 or bad replicas
- Delete the file from iRODS
- Do the put from scratch

Initial implementation here is server-specific, but probably this can be redone and simplified to check replicas immediately upon upload failure, delete, then retry, all in the same process.